### PR TITLE
Add tests that exercise C and D1 control_release_marking.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,14 +2,14 @@ lazy val root = (project in file(".")).
   settings(
     inThisBuild(List(
       organization := "com.tresys",
-      version      := "0.0.4",
+      version      := "0.0.5",
       scalaVersion := "2.12.6",
       crossPaths := false,
       testOptions += Tests.Argument(TestFrameworks.JUnit, "-v"),
     )),
     name := "dfdl-mil-std-2045",
     libraryDependencies := Seq(
-      "org.apache.daffodil" %% "daffodil-tdml-processor" % "2.4.0" % "test",
+      "org.apache.daffodil" %% "daffodil-tdml-processor" % "2.4.5" % "test",
       "junit" % "junit" % "4.12" % "test",
       "com.novocode" % "junit-interface" % "0.11" % "test",
     )

--- a/src/test/resources/com/tresys/mil-std-2045/milstd2045.tdml
+++ b/src/test/resources/com/tresys/mil-std-2045/milstd2045.tdml
@@ -712,5 +712,301 @@ SOFTWARE.
     </tdml:dfdlInfoset>
   </tdml:infoset>
   </tdml:parserTestCase>
+
+  <tdml:parserTestCase 
+    name="test_2045_D1_minimum_size_header" 
+    root="milstd2045_application_header"
+    model="hdr" 
+    description='Smallest possible header'
+    roundTrip="none">
+    <tdml:document bitOrder="LSBFirst">
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[Version                       0100]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[FPI Data compression type        0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Originator address group     0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Recipient address group      0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Information address group    0]]></tdml:documentPart><!-- 8 -->
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[FPI header_size                  0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI future use One               0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI future use 2                 0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI future use 3                 0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI future use 4                 0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI future use 5                 0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GRI message handling group (last)0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[UMF                           0000]]></tdml:documentPart><!-- 16 -->
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[FPI message standard version     0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI vmf message ident group      0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[FPI file name                    0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[FPI message size                 0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[Operation Indicator             00]]></tdml:documentPart><!-- 24 -->
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[Retransmit Indicator             0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[Message Precendence Code       000]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[Security Classification         00]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[FPI C/R marking                  0]]></tdml:documentPart><!-- 32 -->
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Originator DTG               0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Perisability DTG             0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Acknowledgment Request grp   0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Response data group          0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Reference message data grp   0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Future use 6                 0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Future use 7                 0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Future use 8                 0]]></tdml:documentPart><!-- 40 -->
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Future use 9                 0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Future use Ten               0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Message Security group       0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Future use Eleven            0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Future use Twelve            0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Future use Thirteen          0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Future use Fourteen          0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Future use Fifteen           0]]></tdml:documentPart><!-- 48 -->
+    </tdml:document>
+
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:milstd2045_application_header>
+          <version>
+            <value>4</value>
+          </version>
+          <futureUseGroup1/>
+          <message_handling_group>
+            <umf>
+              <value>0</value>
+            </umf>
+            <operation_indicator>
+              <value>0</value>
+            </operation_indicator>
+            <retransmit_indicator>
+              <value>0</value>
+            </retransmit_indicator>
+            <message_precedence_codes>
+              <value>0</value>
+            </message_precedence_codes>
+            <security_classification>
+              <value>0</value>
+            </security_classification>
+            <futureUseGroup2/>
+          </message_handling_group>
+          <futureUseGroup3/>
+        </ex:milstd2045_application_header>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase 
+    name="test_2045_C_minimum_size_header" 
+    root="milstd2045_application_header"
+    model="hdr" 
+    description='Smallest possible header'
+    roundTrip="none">
+    <tdml:document bitOrder="LSBFirst">
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[Version                       0010]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[FPI Data compression type        0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Originator address group     0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Recipient address group      0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Information address group    0]]></tdml:documentPart><!-- 8 -->
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[FPI header_size                  0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GRI message handling group (last)0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[UMF                           0000]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[FPI message standard version     0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI vmf message ident group      0]]></tdml:documentPart><!-- 16 -->
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[FPI file name                    0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[FPI message size                 0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[Operation Indicator             00]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[Retransmit Indicator             0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[Message Precendence Code       000]]></tdml:documentPart><!-- ends at 24 -->
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[Security Classification         00]]></tdml:documentPart><!-- 25 -->
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[FPI C/R marking                  0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Originator DTG               0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Perisability DTG             0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Acknowledgment Request grp   0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Response data group          0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Reference message data grp   0]]></tdml:documentPart><!-- 32 -->
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Message Security group       0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[Padding                    0000000]]></tdml:documentPart><!-- 40 -->
+    </tdml:document>
+
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:milstd2045_application_header>
+          <version>
+            <value>2</value>
+          </version>
+          <message_handling_group>
+            <umf>
+              <value>0</value>
+            </umf>
+            <operation_indicator>
+              <value>0</value>
+            </operation_indicator>
+            <retransmit_indicator>
+              <value>0</value>
+            </retransmit_indicator>
+            <message_precedence_codes>
+              <value>0</value>
+            </message_precedence_codes>
+            <security_classification>
+              <value>0</value>
+            </security_classification>
+          </message_handling_group>
+        </ex:milstd2045_application_header>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+
+
+  <tdml:parserTestCase 
+    name="test_2045_D1_control_release_marking1" 
+    root="milstd2045_application_header"
+    model="hdr" 
+    description='Exercises the control_release_marking_D1  element which is inside a choice.'>
+    <tdml:document bitOrder="LSBFirst">
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[Version                       0100]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[FPI Data compression type        0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Originator address group     0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Recipient address group      0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Information address group    0]]></tdml:documentPart><!-- 8 -->
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[FPI header_size                  0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI future use One               0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI future use 2                 0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI future use 3                 0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI future use 4                 0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI future use 5                 0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GRI message handling group (last)0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[UMF                          000 0]]></tdml:documentPart><!-- 16 -->
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[FPI message standard version     0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI vmf message ident group      0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[FPI file name                    0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[FPI message size                 0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[Operation Indicator             00]]></tdml:documentPart><!-- 24 -->
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[Retransmit Indicator             0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[Message Precendence Code       000]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[Security Classification         00]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[FPI C/R marking                  1]]></tdml:documentPart><!-- 32 -->
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[FRI C/R Marking (Last)           0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[C/R Marking             00000 0000]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Originator DTG               0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Perisability DTG             0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Acknowledgment Request grp   0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Response data group          0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Reference message data grp   0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Future use 6                 0]]></tdml:documentPart><!-- 48 -->
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Future use 7                 0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Future use 8                 0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Future use 9                 0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Future use Ten               0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Message Security group       0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Future use Eleven            0]]></tdml:documentPart><!-- 54 -->
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Future use Twelve            0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Future use Thirteen          0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Future use Fourteen          0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Future use Fifteen           0]]></tdml:documentPart><!-- 58 -->
+      
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[Padding                     000000]]></tdml:documentPart><!-- 64 -->
+      
+    </tdml:document>
+
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:milstd2045_application_header>
+          <version>
+            <value>4</value>
+          </version>
+          <futureUseGroup1/>
+          <message_handling_group>
+            <umf>
+              <value>0</value>
+            </umf>
+            <operation_indicator>
+              <value>0</value>
+            </operation_indicator>
+            <retransmit_indicator>
+              <value>0</value>
+            </retransmit_indicator>
+            <message_precedence_codes>
+              <value>0</value>
+            </message_precedence_codes>
+            <security_classification>
+              <value>0</value>
+            </security_classification>
+            <control_release_marking_D1>
+              <value>0</value>
+            </control_release_marking_D1>
+            <futureUseGroup2/>
+          </message_handling_group>
+          <futureUseGroup3/>
+        </ex:milstd2045_application_header>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+  
+    <tdml:parserTestCase 
+    name="test_2045_C_control_release_marking1" 
+    root="milstd2045_application_header"
+    model="hdr" 
+    description='Exercises the control_release_marking_D1  element which is inside a choice.'>
+    <tdml:document bitOrder="LSBFirst">
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[Version                       0010]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[FPI Data compression type        0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Originator address group     0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Recipient address group      0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Information address group    0]]></tdml:documentPart><!-- 8 -->
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[FPI header_size                  0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GRI message handling group (last)0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[UMF                          000 0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[FPI message standard version     0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI vmf message ident group      0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[FPI file name                    0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[FPI message size                 0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[Operation Indicator             00]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[Retransmit Indicator             0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[Message Precendence Code       000]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[Security Classification         00]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[FPI C/R marking                  1]]></tdml:documentPart>
+      <tdml:documentPart type="text" 
+        encoding="X-DFDL-US-ASCII-7-BIT-PACKED"
+        bitOrder="LSBFirst" replaceDFDLEntities="true"><![CDATA[MARKING%DEL;]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Originator DTG               0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Perisability DTG             0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Acknowledgment Request grp   0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Response data group          0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Reference message data grp   0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Message Security group       0]]></tdml:documentPart>
+      
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[Padding                    0000000]]></tdml:documentPart>
+      
+    </tdml:document>
+
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:milstd2045_application_header>
+          <version>
+            <value>2</value>
+          </version>
+          <message_handling_group>
+            <umf>
+              <value>0</value>
+            </umf>
+            <operation_indicator>
+              <value>0</value>
+            </operation_indicator>
+            <retransmit_indicator>
+              <value>0</value>
+            </retransmit_indicator>
+            <message_precedence_codes>
+              <value>0</value>
+            </message_precedence_codes>
+            <security_classification>
+              <value>0</value>
+            </security_classification>
+            <control_release_marking_C>
+              <value>MARKING</value>
+            </control_release_marking_C>
+          </message_handling_group>
+        </ex:milstd2045_application_header>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+  
+
 </tdml:testSuite>
 

--- a/src/test/scala/com/tresys/mil_std_2045/Test2045Hdr.scala
+++ b/src/test/scala/com/tresys/mil_std_2045/Test2045Hdr.scala
@@ -61,4 +61,20 @@ class Test2045Hdr {
   @Test def test_2045_C_msghdr2() {
     runner.runOneTest("test_2045_C_msghdr2")
   }
+
+  @Test def test_2045_D1_minimum_size_header() {
+    runner.runOneTest("test_2045_D1_minimum_size_header")
+  }
+
+  @Test def test_2045_C_minimum_size_header() {
+    runner.runOneTest("test_2045_C_minimum_size_header")
+  }
+
+  @Test def test_2045_D1_control_release_marking1() {
+    runner.runOneTest("test_2045_D1_control_release_marking1")
+  }
+
+  @Test def test_2045_C_control_release_marking1() {
+    runner.runOneTest("test_2045_C_control_release_marking1")
+  }
 }


### PR DESCRIPTION
Now depends on daffodil 2.5.0 since that has the fix that allows these
new tests to work. 

However, the DFDL schema for mil-std-2045 has not changed. Only the
daffodil-dependency, and new tests were added.

However, given that without daffodil version 2.5.0 this schema had a
major problem, this dependency change warrants a new version of the
schema. So advanced to version 0.0.5.

Also added tests that create and test minimum sized messages. 