### PR TITLE
hides annoying empty futureUseGroupN elements, adds assert that payload is uncompresed.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 /.cache
 /bin
 /lib_managed
-target/
+/target
 project/target/
 .cache-tests
 .cache-main

--- a/build.sbt
+++ b/build.sbt
@@ -2,14 +2,14 @@ lazy val root = (project in file(".")).
   settings(
     inThisBuild(List(
       organization := "com.tresys",
-      version      := "0.0.4",
+      version      := "0.0.5",
       scalaVersion := "2.12.6",
       crossPaths := false,
       testOptions += Tests.Argument(TestFrameworks.JUnit, "-v"),
     )),
     name := "dfdl-mil-std-2045",
     libraryDependencies := Seq(
-      "org.apache.daffodil" %% "daffodil-tdml-processor" % "2.4.0" % "test",
+      "org.apache.daffodil" %% "daffodil-tdml-processor" % "2.4.5" % "test",
       "junit" % "junit" % "4.12" % "test",
       "com.novocode" % "junit-interface" % "0.11" % "test",
     )

--- a/build.sbt
+++ b/build.sbt
@@ -2,14 +2,14 @@ lazy val root = (project in file(".")).
   settings(
     inThisBuild(List(
       organization := "com.tresys",
-      version      := "0.0.5",
+      version      := "0.0.6",
       scalaVersion := "2.12.6",
       crossPaths := false,
       testOptions += Tests.Argument(TestFrameworks.JUnit, "-v"),
     )),
     name := "dfdl-mil-std-2045",
     libraryDependencies := Seq(
-      "org.apache.daffodil" %% "daffodil-tdml-processor" % "2.4.5" % "test",
+      "org.apache.daffodil" %% "daffodil-tdml-processor" % "2.5.0" % "test",
       "junit" % "junit" % "4.12" % "test",
       "com.novocode" % "junit-interface" % "0.11" % "test",
     )

--- a/src/main/resources/com/tresys/mil-std-2045/xsd/milstd2045_application_header.dfdl.xsd
+++ b/src/main/resources/com/tresys/mil-std-2045/xsd/milstd2045_application_header.dfdl.xsd
@@ -48,26 +48,10 @@
       <dfdl:defineVariable name="versionSpec" type="xs:string" defaultValue="C"/>
     </xs:appinfo>
   </xs:annotation>
-  
-  <xs:complexType name="future_use_group_type">
-    <xs:sequence>
-      <xs:element name="group_size" type="tns:tIntField" dfdl:length="12" dfdl:outputValueCalc=" { (fn:count(../future_use_group_data/word) * 32) +   (fn:count(../future_use_group_data/partialWord) * dfdl:valueLength(../future_use_group_data/partialWord, 'bits')) }"/>
-      <!-- DFDL doesn't allow length units of 'bits' for xs:nonNegativeInteger, 
-           So we use an array of unsigned int, for this opaque region. -->
-      <xs:element name="future_use_group_data">
-        <xs:complexType>
-          <xs:sequence>
-            <xs:element maxOccurs="128" minOccurs="0" name="word" type="tns:tIntField" dfdl:length="32" dfdl:occursCount="{ ../../group_size idiv 32 }" dfdl:occursCountKind="expression"/>
-            <xs:element maxOccurs="1" minOccurs="0" name="partialWord" type="tns:tIntField" dfdl:length="{ ../../group_size mod 32 }" dfdl:occursCount="{ if ((../../group_size mod 32) ne 0) then 1 else 0 }" dfdl:occursCountKind="expression"/>
-          </xs:sequence>
-        </xs:complexType>
-      </xs:element>
-    </xs:sequence>
-  </xs:complexType>
 
   <xs:complexType name="milstd2045_application_header_type">
     <xs:sequence>
-      <xs:element name="version" dfdl:lengthKind="implicit">
+      <xs:element name="version">
         <xs:complexType>
           <xs:sequence>
             <xs:element name="value" type="tns:tIntField" dfdl:length="4">
@@ -89,10 +73,19 @@
       <xs:choice>
         <xs:sequence>
           <xs:sequence dfdl:hiddenGroupRef="msi:PI_true" />
-          <xs:element name="data_compression_type" dfdl:lengthKind="implicit">
+          <xs:element name="data_compression_type">
             <xs:complexType>
               <xs:sequence>
-                <xs:element name="value" type="tns:tIntField" dfdl:length="2" />
+                <xs:element name="value" type="tns:tIntField" dfdl:length="2">
+                  <xs:annotation>
+                    <xs:appinfo source="http://www.ogf.org/dfdl/">
+                      <dfdl:assert 
+                        message="Compression is not supported in this version of the mil-std-2045 header DFDL schema.">{
+                       fn:true() 
+                      }</dfdl:assert>
+                    </xs:appinfo>
+                  </xs:annotation>
+                </xs:element>
               </xs:sequence>
             </xs:complexType>
           </xs:element>
@@ -108,7 +101,7 @@
                 <xs:choice>
                   <xs:sequence>
                     <xs:sequence dfdl:hiddenGroupRef="msi:PI_true" />
-                    <xs:element name="urn" dfdl:lengthKind="implicit">
+                    <xs:element name="urn">
                       <xs:complexType>
                         <xs:sequence>
                           <xs:element name="value" type="tns:tIntField" dfdl:length="24" />
@@ -139,7 +132,7 @@
         <xs:sequence>
           <xs:sequence dfdl:hiddenGroupRef="msi:PI_true" />
           <xs:element maxOccurs="unbounded" minOccurs="1" name="recipient_address_group"
-            dfdl:lengthKind="implicit" dfdl:occursCountKind="implicit">
+            dfdl:occursCountKind="implicit">
             <xs:complexType>
               <xs:sequence>
                 <xs:sequence>
@@ -157,7 +150,7 @@
                 <xs:choice>
                   <xs:sequence>
                     <xs:sequence dfdl:hiddenGroupRef="msi:PI_true" />
-                    <xs:element name="urn" dfdl:lengthKind="implicit">
+                    <xs:element name="urn">
                       <xs:complexType>
                         <xs:sequence>
                           <xs:element name="value" type="tns:tIntField" dfdl:length="24" />
@@ -188,7 +181,7 @@
         <xs:sequence>
           <xs:sequence dfdl:hiddenGroupRef="msi:PI_true" />
           <xs:element maxOccurs="unbounded" minOccurs="1" name="information_address_group"
-            dfdl:lengthKind="implicit" dfdl:occursCountKind="implicit">
+            dfdl:occursCountKind="implicit">
             <xs:complexType>
               <xs:sequence>
                 <xs:sequence>
@@ -206,7 +199,7 @@
                 <xs:choice>
                   <xs:sequence>
                     <xs:sequence dfdl:hiddenGroupRef="msi:PI_true" />
-                    <xs:element name="urn" dfdl:lengthKind="implicit">
+                    <xs:element name="urn">
                       <xs:complexType>
                         <xs:sequence>
                           <xs:element name="value" type="tns:tIntField" dfdl:length="24" />
@@ -236,7 +229,7 @@
       <xs:choice>
         <xs:sequence>
           <xs:sequence dfdl:hiddenGroupRef="msi:PI_true" />
-          <xs:element name="header_size" dfdl:lengthKind="implicit">
+          <xs:element name="header_size">
             <xs:complexType>
               <xs:sequence>
                 <xs:element name="value" type="tns:tIntField" dfdl:length="16"
@@ -250,7 +243,7 @@
       <xs:group ref="tns:futureUseGroup1To5"/>
       <!-- start message handling group -->
       <xs:element maxOccurs="unbounded" minOccurs="1" name="message_handling_group"
-        dfdl:lengthKind="implicit" dfdl:occursCountKind="implicit">
+        dfdl:occursCountKind="implicit">
         <xs:complexType>
           <xs:sequence>
             <xs:sequence>
@@ -265,7 +258,7 @@
               </xs:annotation>
             </xs:sequence>
             <xs:sequence dfdl:hiddenGroupRef="msi:GRI" />
-            <xs:element name="umf" dfdl:lengthKind="implicit">
+            <xs:element name="umf">
               <xs:complexType>
                 <xs:sequence>
                   <xs:element name="value" type="tns:tIntField" dfdl:length="4" />
@@ -275,7 +268,7 @@
             <xs:choice>
               <xs:sequence>
                 <xs:sequence dfdl:hiddenGroupRef="msi:PI_true" />
-                <xs:element name="message_standard_version" dfdl:lengthKind="implicit">
+                <xs:element name="message_standard_version">
                   <xs:complexType>
                     <xs:sequence>
                       <xs:element name="value" type="tns:tIntField" dfdl:length="4" />
@@ -291,7 +284,7 @@
                 <xs:element name="vmf_message_identification_group">
                   <xs:complexType>
                     <xs:sequence>
-                      <xs:element name="fad" dfdl:lengthKind="implicit">
+                      <xs:element name="fad">
                         <xs:complexType>
                           <xs:sequence>
                             <xs:element name="value" type="tns:tIntField"
@@ -299,7 +292,7 @@
                           </xs:sequence>
                         </xs:complexType>
                       </xs:element>
-                      <xs:element name="message_number" dfdl:lengthKind="implicit">
+                      <xs:element name="message_number">
                         <xs:complexType>
                           <xs:sequence>
                             <xs:element name="value" type="tns:tIntField"
@@ -310,7 +303,7 @@
                       <xs:choice>
                         <xs:sequence>
                           <xs:sequence dfdl:hiddenGroupRef="msi:PI_true" />
-                          <xs:element name="message_subtype" dfdl:lengthKind="implicit">
+                          <xs:element name="message_subtype">
                             <xs:complexType>
                               <xs:sequence>
                                 <xs:element name="value" type="tns:tIntField"
@@ -348,28 +341,28 @@
               </xs:sequence>
               <xs:sequence dfdl:hiddenGroupRef="msi:PI_false" />
             </xs:choice>
-            <xs:element name="operation_indicator" dfdl:lengthKind="implicit">
+            <xs:element name="operation_indicator">
               <xs:complexType>
                 <xs:sequence>
                   <xs:element name="value" type="tns:tIntField" dfdl:length="2" />
                 </xs:sequence>
               </xs:complexType>
             </xs:element>
-            <xs:element name="retransmit_indicator" dfdl:lengthKind="implicit">
+            <xs:element name="retransmit_indicator">
               <xs:complexType>
                 <xs:sequence>
                   <xs:element name="value" type="tns:tIntField" dfdl:length="1" />
                 </xs:sequence>
               </xs:complexType>
             </xs:element>
-            <xs:element name="message_precedence_codes" dfdl:lengthKind="implicit">
+            <xs:element name="message_precedence_codes">
               <xs:complexType>
                 <xs:sequence>
                   <xs:element name="value" type="tns:tIntField" dfdl:length="3" />
                 </xs:sequence>
               </xs:complexType>
             </xs:element>
-            <xs:element name="security_classification" dfdl:lengthKind="implicit">
+            <xs:element name="security_classification">
               <xs:complexType>
                 <xs:sequence>
                   <xs:element name="value" type="tns:tIntField" dfdl:length="2" />
@@ -381,7 +374,7 @@
                 <xs:sequence dfdl:hiddenGroupRef="msi:PI_true" />
                 <xs:choice dfdl:choiceDispatchKey="{ $tns:versionSpec }">
                   <xs:element dfdl:choiceBranchKey="D1" maxOccurs="unbounded" minOccurs="1" name="control_release_marking_D1"
-                    dfdl:lengthKind="implicit" dfdl:occursCountKind="implicit">
+                    dfdl:occursCountKind="implicit">
                     <xs:complexType>
                       <xs:sequence>
                         <xs:sequence>
@@ -416,7 +409,7 @@
                 <xs:element name="originator_dtg_group">
                   <xs:complexType>
                     <xs:sequence>
-                      <xs:element name="year" dfdl:lengthKind="implicit">
+                      <xs:element name="year">
                         <xs:complexType>
                           <xs:sequence>
                             <xs:element name="value" type="tns:tIntField"
@@ -424,7 +417,7 @@
                           </xs:sequence>
                         </xs:complexType>
                       </xs:element>
-                      <xs:element name="month" dfdl:lengthKind="implicit">
+                      <xs:element name="month">
                         <xs:complexType>
                           <xs:sequence>
                             <xs:element name="value" type="tns:tIntField"
@@ -432,7 +425,7 @@
                           </xs:sequence>
                         </xs:complexType>
                       </xs:element>
-                      <xs:element name="day" dfdl:lengthKind="implicit">
+                      <xs:element name="day">
                         <xs:complexType>
                           <xs:sequence>
                             <xs:element name="value" type="tns:tIntField"
@@ -440,7 +433,7 @@
                           </xs:sequence>
                         </xs:complexType>
                       </xs:element>
-                      <xs:element name="hour" dfdl:lengthKind="implicit">
+                      <xs:element name="hour">
                         <xs:complexType>
                           <xs:sequence>
                             <xs:element name="value" type="tns:tIntField"
@@ -448,7 +441,7 @@
                           </xs:sequence>
                         </xs:complexType>
                       </xs:element>
-                      <xs:element name="minute" dfdl:lengthKind="implicit">
+                      <xs:element name="minute">
                         <xs:complexType>
                           <xs:sequence>
                             <xs:element name="value" type="tns:tIntField"
@@ -456,7 +449,7 @@
                           </xs:sequence>
                         </xs:complexType>
                       </xs:element>
-                      <xs:element name="second" dfdl:lengthKind="implicit">
+                      <xs:element name="second">
                         <xs:complexType>
                           <xs:sequence>
                             <xs:element name="value" type="tns:tIntField"
@@ -467,7 +460,7 @@
                       <xs:choice>
                         <xs:sequence>
                           <xs:sequence dfdl:hiddenGroupRef="msi:PI_true" />
-                          <xs:element name="dtg_extension" dfdl:lengthKind="implicit">
+                          <xs:element name="dtg_extension">
                             <xs:complexType>
                               <xs:sequence>
                                 <xs:element name="value" type="tns:tIntField"
@@ -490,7 +483,7 @@
                 <xs:element name="perishability_dtg_group">
                   <xs:complexType>
                     <xs:sequence>
-                      <xs:element name="year" dfdl:lengthKind="implicit">
+                      <xs:element name="year">
                         <xs:complexType>
                           <xs:sequence>
                             <xs:element name="value" type="tns:tIntField"
@@ -498,7 +491,7 @@
                           </xs:sequence>
                         </xs:complexType>
                       </xs:element>
-                      <xs:element name="month" dfdl:lengthKind="implicit">
+                      <xs:element name="month">
                         <xs:complexType>
                           <xs:sequence>
                             <xs:element name="value" type="tns:tIntField"
@@ -506,7 +499,7 @@
                           </xs:sequence>
                         </xs:complexType>
                       </xs:element>
-                      <xs:element name="day" dfdl:lengthKind="implicit">
+                      <xs:element name="day">
                         <xs:complexType>
                           <xs:sequence>
                             <xs:element name="value" type="tns:tIntField"
@@ -514,7 +507,7 @@
                           </xs:sequence>
                         </xs:complexType>
                       </xs:element>
-                      <xs:element name="hour" dfdl:lengthKind="implicit">
+                      <xs:element name="hour">
                         <xs:complexType>
                           <xs:sequence>
                             <xs:element name="value" type="tns:tIntField"
@@ -522,7 +515,7 @@
                           </xs:sequence>
                         </xs:complexType>
                       </xs:element>
-                      <xs:element name="minute" dfdl:lengthKind="implicit">
+                      <xs:element name="minute">
                         <xs:complexType>
                           <xs:sequence>
                             <xs:element name="value" type="tns:tIntField"
@@ -530,7 +523,7 @@
                           </xs:sequence>
                         </xs:complexType>
                       </xs:element>
-                      <xs:element name="second" dfdl:lengthKind="implicit">
+                      <xs:element name="second">
                         <xs:complexType>
                           <xs:sequence>
                             <xs:element name="value" type="tns:tIntField"
@@ -551,7 +544,7 @@
                   <xs:complexType>
                     <xs:sequence>
                       <xs:element name="machine_acknowledge_request_indicator"
-                        dfdl:lengthKind="implicit">
+                       >
                         <xs:complexType>
                           <xs:sequence>
                             <xs:element name="value" type="tns:tIntField"
@@ -560,7 +553,7 @@
                         </xs:complexType>
                       </xs:element>
                       <xs:element name="operator_acknowledge_request_indicator"
-                        dfdl:lengthKind="implicit">
+                       >
                         <xs:complexType>
                           <xs:sequence>
                             <xs:element name="value" type="tns:tIntField"
@@ -569,7 +562,7 @@
                         </xs:complexType>
                       </xs:element>
                       <xs:element name="operator_reply_request_indicator"
-                        dfdl:lengthKind="implicit">
+                       >
                         <xs:complexType>
                           <xs:sequence>
                             <xs:element name="value" type="tns:tIntField"
@@ -589,7 +582,7 @@
                 <xs:element name="response_data_group">
                   <xs:complexType>
                     <xs:sequence>
-                      <xs:element name="year" dfdl:lengthKind="implicit">
+                      <xs:element name="year">
                         <xs:complexType>
                           <xs:sequence>
                             <xs:element name="value" type="tns:tIntField"
@@ -597,7 +590,7 @@
                           </xs:sequence>
                         </xs:complexType>
                       </xs:element>
-                      <xs:element name="month" dfdl:lengthKind="implicit">
+                      <xs:element name="month">
                         <xs:complexType>
                           <xs:sequence>
                             <xs:element name="value" type="tns:tIntField"
@@ -605,7 +598,7 @@
                           </xs:sequence>
                         </xs:complexType>
                       </xs:element>
-                      <xs:element name="day" dfdl:lengthKind="implicit">
+                      <xs:element name="day">
                         <xs:complexType>
                           <xs:sequence>
                             <xs:element name="value" type="tns:tIntField"
@@ -613,7 +606,7 @@
                           </xs:sequence>
                         </xs:complexType>
                       </xs:element>
-                      <xs:element name="hour" dfdl:lengthKind="implicit">
+                      <xs:element name="hour">
                         <xs:complexType>
                           <xs:sequence>
                             <xs:element name="value" type="tns:tIntField"
@@ -621,7 +614,7 @@
                           </xs:sequence>
                         </xs:complexType>
                       </xs:element>
-                      <xs:element name="minute" dfdl:lengthKind="implicit">
+                      <xs:element name="minute">
                         <xs:complexType>
                           <xs:sequence>
                             <xs:element name="value" type="tns:tIntField"
@@ -629,7 +622,7 @@
                           </xs:sequence>
                         </xs:complexType>
                       </xs:element>
-                      <xs:element name="second" dfdl:lengthKind="implicit">
+                      <xs:element name="second">
                         <xs:complexType>
                           <xs:sequence>
                             <xs:element name="value" type="tns:tIntField"
@@ -640,7 +633,7 @@
                       <xs:choice>
                         <xs:sequence>
                           <xs:sequence dfdl:hiddenGroupRef="msi:PI_true" />
-                          <xs:element name="dtg_extension" dfdl:lengthKind="implicit">
+                          <xs:element name="dtg_extension">
                             <xs:complexType>
                               <xs:sequence>
                                 <xs:element name="value" type="tns:tIntField"
@@ -651,7 +644,7 @@
                         </xs:sequence>
                         <xs:sequence dfdl:hiddenGroupRef="msi:PI_false" />
                       </xs:choice>
-                      <xs:element name="r_c" dfdl:lengthKind="implicit">
+                      <xs:element name="r_c">
                         <xs:complexType>
                           <xs:sequence>
                             <xs:element name="value" type="tns:tIntField"
@@ -662,7 +655,7 @@
                       <xs:choice>
                         <xs:sequence>
                           <xs:sequence dfdl:hiddenGroupRef="msi:PI_true" />
-                          <xs:element name="cantco_reason_code" dfdl:lengthKind="implicit">
+                          <xs:element name="cantco_reason_code">
                             <xs:complexType>
                               <xs:sequence>
                                 <xs:element name="value" type="tns:tIntField"
@@ -676,7 +669,7 @@
                       <xs:choice>
                         <xs:sequence>
                           <xs:sequence dfdl:hiddenGroupRef="msi:PI_true" />
-                          <xs:element name="cantpro_reason_code" dfdl:lengthKind="implicit">
+                          <xs:element name="cantpro_reason_code">
                             <xs:complexType>
                               <xs:sequence>
                                 <xs:element name="value" type="tns:tIntField"
@@ -708,7 +701,7 @@
               <xs:sequence>
                 <xs:sequence dfdl:hiddenGroupRef="msi:PI_true" />
                 <xs:element maxOccurs="unbounded" minOccurs="1"
-                  name="reference_message_data_group" dfdl:lengthKind="implicit"
+                  name="reference_message_data_group"
                   dfdl:occursCountKind="implicit">
                   <xs:complexType>
                     <xs:sequence>
@@ -728,7 +721,7 @@
                       <xs:choice>
                         <xs:sequence>
                           <xs:sequence dfdl:hiddenGroupRef="msi:PI_true" />
-                          <xs:element name="urn" dfdl:lengthKind="implicit">
+                          <xs:element name="urn">
                             <xs:complexType>
                               <xs:sequence>
                                 <xs:element name="value" type="tns:tIntField"
@@ -750,7 +743,7 @@
                         </xs:sequence>
                         <xs:sequence dfdl:hiddenGroupRef="msi:PI_false" />
                       </xs:choice>
-                      <xs:element name="year" dfdl:lengthKind="implicit">
+                      <xs:element name="year">
                         <xs:complexType>
                           <xs:sequence>
                             <xs:element name="value" type="tns:tIntField"
@@ -758,7 +751,7 @@
                           </xs:sequence>
                         </xs:complexType>
                       </xs:element>
-                      <xs:element name="month" dfdl:lengthKind="implicit">
+                      <xs:element name="month">
                         <xs:complexType>
                           <xs:sequence>
                             <xs:element name="value" type="tns:tIntField"
@@ -766,7 +759,7 @@
                           </xs:sequence>
                         </xs:complexType>
                       </xs:element>
-                      <xs:element name="day" dfdl:lengthKind="implicit">
+                      <xs:element name="day">
                         <xs:complexType>
                           <xs:sequence>
                             <xs:element name="value" type="tns:tIntField"
@@ -774,7 +767,7 @@
                           </xs:sequence>
                         </xs:complexType>
                       </xs:element>
-                      <xs:element name="hour" dfdl:lengthKind="implicit">
+                      <xs:element name="hour">
                         <xs:complexType>
                           <xs:sequence>
                             <xs:element name="value" type="tns:tIntField"
@@ -782,7 +775,7 @@
                           </xs:sequence>
                         </xs:complexType>
                       </xs:element>
-                      <xs:element name="minute" dfdl:lengthKind="implicit">
+                      <xs:element name="minute">
                         <xs:complexType>
                           <xs:sequence>
                             <xs:element name="value" type="tns:tIntField"
@@ -790,7 +783,7 @@
                           </xs:sequence>
                         </xs:complexType>
                       </xs:element>
-                      <xs:element name="second" dfdl:lengthKind="implicit">
+                      <xs:element name="second">
                         <xs:complexType>
                           <xs:sequence>
                             <xs:element name="value" type="tns:tIntField"
@@ -801,7 +794,7 @@
                       <xs:choice>
                         <xs:sequence>
                           <xs:sequence dfdl:hiddenGroupRef="msi:PI_true" />
-                          <xs:element name="dtg_extension" dfdl:lengthKind="implicit">
+                          <xs:element name="dtg_extension">
                             <xs:complexType>
                               <xs:sequence>
                                 <xs:element name="value" type="tns:tIntField"
@@ -845,7 +838,7 @@
           <xs:element name="message_security_group">
             <xs:complexType>
               <xs:sequence>
-                <xs:element name="security_parameters_information" dfdl:lengthKind="implicit">
+                <xs:element name="security_parameters_information">
                   <xs:complexType>
                     <xs:sequence>
                       <xs:element name="value" type="tns:tIntField" dfdl:length="4"/>
@@ -858,14 +851,14 @@
                     <xs:element name="keying_material_group">
                       <xs:complexType>
                         <xs:sequence>
-                          <xs:element name="keying_material_id_length" dfdl:lengthKind="implicit">
+                          <xs:element name="keying_material_id_length">
                             <xs:complexType>
                               <xs:sequence>
                                 <xs:element name="value" type="tns:tIntField" dfdl:length="3" dfdl:outputValueCalc="{ dfdl:valueLength(../../keying_material_id/value, 'bytes') - 1 }"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
-                          <xs:element name="keying_material_id" dfdl:lengthKind="implicit">
+                          <xs:element name="keying_material_id">
                             <xs:complexType>
                               <xs:sequence>
                                 <xs:element name="value" type="tns:tHexBinary" dfdl:length="{ ../../keying_material_id_length/value + 1 }" dfdl:lengthUnits="bytes"/>
@@ -884,14 +877,14 @@
                     <xs:element name="cryptographic_initialization_group">
                       <xs:complexType>
                         <xs:sequence>
-                          <xs:element name="cryptographic_initialization_length" dfdl:lengthKind="implicit">
+                          <xs:element name="cryptographic_initialization_length">
                             <xs:complexType>
                               <xs:sequence>
                                 <xs:element name="value" type="tns:tIntField" dfdl:length="4" dfdl:outputValueCalc="{ (dfdl:valueLength(../../cryptographic_initialization/value, 'bytes') idiv 8) - 1 }"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
-                          <xs:element name="cryptographic_initialization" dfdl:lengthKind="implicit">
+                          <xs:element name="cryptographic_initialization">
                             <xs:complexType>
                               <xs:sequence>
                                 <xs:element name="value" type="tns:tHexBinary" dfdl:length="{ (../../cryptographic_initialization_length/value + 1) * 8 }" dfdl:lengthUnits="bytes"/>
@@ -910,14 +903,14 @@
                     <xs:element name="key_token_group">
                       <xs:complexType>
                         <xs:sequence>
-                          <xs:element name="key_token_length" dfdl:lengthKind="implicit">
+                          <xs:element name="key_token_length">
                             <xs:complexType>
                               <xs:sequence>
                                 <xs:element name="value" type="tns:tIntField" dfdl:length="8" dfdl:outputValueCalc="{ (dfdl:valueLength(../../key_token[1]/value, 'bytes') idiv 8) - 1 }"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
-                          <xs:element maxOccurs="unbounded" minOccurs="1" name="key_token" dfdl:lengthKind="implicit" dfdl:occursCountKind="implicit">
+                          <xs:element maxOccurs="unbounded" minOccurs="1" name="key_token" dfdl:occursCountKind="implicit">
                             <xs:complexType>
                               <xs:sequence>
                                 <xs:sequence>
@@ -951,14 +944,14 @@
                     <xs:element name="authentication_data_a_group">
                       <xs:complexType>
                         <xs:sequence>
-                          <xs:element name="authentication_data_a_length" dfdl:lengthKind="implicit">
+                          <xs:element name="authentication_data_a_length">
                             <xs:complexType>
                               <xs:sequence>
                                 <xs:element name="value" type="tns:tIntField" dfdl:length="7" dfdl:outputValueCalc="{ (dfdl:valueLength(../../authentication_data_a/value, 'bytes') idiv 8) - 1 }"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
-                          <xs:element name="authentication_data_a" dfdl:lengthKind="implicit">
+                          <xs:element name="authentication_data_a">
                             <xs:complexType>
                               <xs:sequence>
                                 <xs:element name="value" type="tns:tHexBinary" dfdl:length="{ (../../authentication_data_a_length/value + 1) * 8 }" dfdl:lengthUnits="bytes"/>
@@ -977,14 +970,14 @@
                     <xs:element name="authentication_data_b_group">
                       <xs:complexType>
                         <xs:sequence>
-                          <xs:element name="authentication_data_b_length" dfdl:lengthKind="implicit">
+                          <xs:element name="authentication_data_b_length">
                             <xs:complexType>
                               <xs:sequence>
                                 <xs:element name="value" type="tns:tIntField" dfdl:length="7" dfdl:outputValueCalc="{ (dfdl:valueLength(../../authentication_data_b/value, 'bytes') idiv 8) - 1}"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
-                          <xs:element name="authentication_data_b" dfdl:lengthKind="implicit">
+                          <xs:element name="authentication_data_b">
                             <xs:complexType>
                               <xs:sequence>
                                 <xs:element name="value" type="tns:tHexBinary" dfdl:length="{ (../../authentication_data_b_length/value + 1) * 8 }" dfdl:lengthUnits="bytes"/>
@@ -997,7 +990,7 @@
                   </xs:sequence>
                   <xs:sequence dfdl:hiddenGroupRef="msi:PI_false"/>
                 </xs:choice>
-                <xs:element name="signed_acknowledge_request_indicator" dfdl:lengthKind="implicit">
+                <xs:element name="signed_acknowledge_request_indicator">
                   <xs:complexType>
                     <xs:sequence>
                       <xs:element name="value" type="tns:tIntField" dfdl:length="1"/>
@@ -1010,7 +1003,7 @@
                     <xs:element name="message_security_padding_group">
                       <xs:complexType>
                         <xs:sequence>
-                          <xs:element name="message_security_padding_length" dfdl:lengthKind="implicit">
+                          <xs:element name="message_security_padding_length">
                             <xs:complexType>
                               <xs:sequence>
                                 <xs:element name="value" type="tns:tIntField" dfdl:length="8" dfdl:outputValueCalc=" { if (fn:exists(../../message_security_padding))   then ((dfdl:valueLength(../../message_security_padding/value, 'bits') idiv 8) - 1)   else 0 }"/>
@@ -1020,7 +1013,7 @@
                           <xs:choice>
                             <xs:sequence>
                               <xs:sequence dfdl:hiddenGroupRef="msi:PI_true"/>
-                              <xs:element name="message_security_padding" dfdl:lengthKind="implicit">
+                              <xs:element name="message_security_padding">
                                 <xs:complexType>
                                   <xs:sequence>
                                     <xs:element name="value" type="tns:tIntField" dfdl:length="{ (../../message_security_padding_length/value + 1) * 8}"/>
@@ -1047,157 +1040,158 @@
 
   <xs:group name="futureUseGroup1To5">
     <xs:sequence>
-      <xs:element name="futureUseGroup1" minOccurs="0" dfdl:occursCountKind="expression"
-        dfdl:occursCount='{ if ($tns:versionSpec eq "D1") then 1 else 0 }'>
-        <xs:complexType>
-          <xs:sequence>
-            <xs:choice>
-              <xs:sequence>
-                <xs:sequence dfdl:hiddenGroupRef="msi:PI_true" />
-                <xs:element name="future_use_1" type="tns:future_use_group_type"
-                  dfdl:lengthKind="implicit" />
-              </xs:sequence>
-              <xs:sequence dfdl:hiddenGroupRef="msi:PI_false" />
-            </xs:choice>
-            <xs:choice>
-              <xs:sequence>
-                <xs:sequence dfdl:hiddenGroupRef="msi:PI_true" />
-                <xs:element name="future_use_2" type="tns:future_use_group_type"
-                  dfdl:lengthKind="implicit" />
-              </xs:sequence>
-              <xs:sequence dfdl:hiddenGroupRef="msi:PI_false" />
-            </xs:choice>
-            <xs:choice>
-              <xs:sequence>
-                <xs:sequence dfdl:hiddenGroupRef="msi:PI_true" />
-                <xs:element name="future_use_3" type="tns:future_use_group_type"
-                  dfdl:lengthKind="implicit" />
-              </xs:sequence>
-              <xs:sequence dfdl:hiddenGroupRef="msi:PI_false" />
-            </xs:choice>
-            <xs:choice>
-              <xs:sequence>
-                <xs:sequence dfdl:hiddenGroupRef="msi:PI_true" />
-                <xs:element name="future_use_4" type="tns:future_use_group_type"
-                  dfdl:lengthKind="implicit" />
-              </xs:sequence>
-              <xs:sequence dfdl:hiddenGroupRef="msi:PI_false" />
-            </xs:choice>
-            <xs:choice>
-              <xs:sequence>
-                <xs:sequence dfdl:hiddenGroupRef="msi:PI_true" />
-                <xs:element name="future_use_5" type="tns:future_use_group_type"
-                  dfdl:lengthKind="implicit" />
-              </xs:sequence>
-              <xs:sequence dfdl:hiddenGroupRef="msi:PI_false" />
-            </xs:choice>
-          </xs:sequence>
-        </xs:complexType>
-      </xs:element>
+      <xs:choice>
+        <xs:sequence>
+          <xs:sequence dfdl:hiddenGroupRef="tns:PI_true_version_D1" />
+          <xs:element name="future_use_1" type="tns:future_use_group_type"/>
+        </xs:sequence>
+        <xs:sequence dfdl:hiddenGroupRef="tns:PI_false_version_D1" />
+      </xs:choice>
+      <xs:choice>
+        <xs:sequence>
+          <xs:sequence dfdl:hiddenGroupRef="tns:PI_true_version_D1" />
+          <xs:element name="future_use_2" type="tns:future_use_group_type"/>
+        </xs:sequence>
+        <xs:sequence dfdl:hiddenGroupRef="tns:PI_false_version_D1" />
+      </xs:choice>
+      <xs:choice>
+        <xs:sequence>
+          <xs:sequence dfdl:hiddenGroupRef="tns:PI_true_version_D1" />
+          <xs:element name="future_use_3" type="tns:future_use_group_type"/>
+        </xs:sequence>
+        <xs:sequence dfdl:hiddenGroupRef="tns:PI_false_version_D1" />
+      </xs:choice>
+      <xs:choice>
+        <xs:sequence>
+          <xs:sequence dfdl:hiddenGroupRef="tns:PI_true_version_D1" />
+          <xs:element name="future_use_4" type="tns:future_use_group_type"/>
+        </xs:sequence>
+        <xs:sequence dfdl:hiddenGroupRef="tns:PI_false_version_D1" />
+      </xs:choice>
+      <xs:choice>
+        <xs:sequence>
+          <xs:sequence dfdl:hiddenGroupRef="tns:PI_true_version_D1" />
+          <xs:element name="future_use_5" type="tns:future_use_group_type"/>
+        </xs:sequence>
+        <xs:sequence dfdl:hiddenGroupRef="tns:PI_false_version_D1" />
+      </xs:choice>
     </xs:sequence>
   </xs:group>
 
   <xs:group name="futureUseGroup6To10">
     <xs:sequence>
-      <xs:element name="futureUseGroup2" minOccurs="0" dfdl:occursCountKind="expression"
-        dfdl:occursCount='{ if ($tns:versionSpec eq "D1") then 1 else 0 }'>
-        <xs:complexType>
-          <xs:sequence>
-            <xs:choice>
-              <xs:sequence>
-                <xs:sequence dfdl:hiddenGroupRef="msi:PI_true" />
-                <xs:element name="future_use_6" type="tns:future_use_group_type"
-                  dfdl:lengthKind="implicit" />
-              </xs:sequence>
-              <xs:sequence dfdl:hiddenGroupRef="msi:PI_false" />
-            </xs:choice>
-            <xs:choice>
-              <xs:sequence>
-                <xs:sequence dfdl:hiddenGroupRef="msi:PI_true" />
-                <xs:element name="future_use_7" type="tns:future_use_group_type"
-                  dfdl:lengthKind="implicit" />
-              </xs:sequence>
-              <xs:sequence dfdl:hiddenGroupRef="msi:PI_false" />
-            </xs:choice>
-            <xs:choice>
-              <xs:sequence>
-                <xs:sequence dfdl:hiddenGroupRef="msi:PI_true" />
-                <xs:element name="future_use_8" type="tns:future_use_group_type"
-                  dfdl:lengthKind="implicit" />
-              </xs:sequence>
-              <xs:sequence dfdl:hiddenGroupRef="msi:PI_false" />
-            </xs:choice>
-            <xs:choice>
-              <xs:sequence>
-                <xs:sequence dfdl:hiddenGroupRef="msi:PI_true" />
-                <xs:element name="future_use_9" type="tns:future_use_group_type"
-                  dfdl:lengthKind="implicit" />
-              </xs:sequence>
-              <xs:sequence dfdl:hiddenGroupRef="msi:PI_false" />
-            </xs:choice>
-            <xs:choice>
-              <xs:sequence>
-                <xs:sequence dfdl:hiddenGroupRef="msi:PI_true" />
-                <xs:element name="future_use_10" type="tns:future_use_group_type"
-                  dfdl:lengthKind="implicit" />
-              </xs:sequence>
-              <xs:sequence dfdl:hiddenGroupRef="msi:PI_false" />
-            </xs:choice>
-          </xs:sequence>
-        </xs:complexType>
-      </xs:element>
+      <xs:choice>
+        <xs:sequence>
+          <xs:sequence dfdl:hiddenGroupRef="tns:PI_true_version_D1" />
+          <xs:element name="future_use_6" type="tns:future_use_group_type" />
+        </xs:sequence>
+        <xs:sequence dfdl:hiddenGroupRef="tns:PI_false_version_D1" />
+      </xs:choice>
+      <xs:choice>
+        <xs:sequence>
+          <xs:sequence dfdl:hiddenGroupRef="tns:PI_true_version_D1" />
+          <xs:element name="future_use_7" type="tns:future_use_group_type" />
+        </xs:sequence>
+        <xs:sequence dfdl:hiddenGroupRef="tns:PI_false_version_D1" />
+      </xs:choice>
+      <xs:choice>
+        <xs:sequence>
+          <xs:sequence dfdl:hiddenGroupRef="tns:PI_true_version_D1" />
+          <xs:element name="future_use_8" type="tns:future_use_group_type"/>
+        </xs:sequence>
+        <xs:sequence dfdl:hiddenGroupRef="tns:PI_false_version_D1" />
+      </xs:choice>
+      <xs:choice>
+        <xs:sequence>
+          <xs:sequence dfdl:hiddenGroupRef="tns:PI_true_version_D1" />
+          <xs:element name="future_use_9" type="tns:future_use_group_type"/>
+        </xs:sequence>
+        <xs:sequence dfdl:hiddenGroupRef="tns:PI_false_version_D1" />
+      </xs:choice>
+      <xs:choice>
+        <xs:sequence>
+          <xs:sequence dfdl:hiddenGroupRef="tns:PI_true_version_D1" />
+          <xs:element name="future_use_10" type="tns:future_use_group_type"/>
+        </xs:sequence>
+        <xs:sequence dfdl:hiddenGroupRef="tns:PI_false_version_D1" />
+      </xs:choice>
     </xs:sequence>
   </xs:group>
 
   <xs:group name="futureUseGroup11To15">
     <xs:sequence>
-      <xs:element name="futureUseGroup3" minOccurs="0" dfdl:occursCountKind="expression"
-        dfdl:occursCount='{ if ($tns:versionSpec eq "D1") then 1 else 0 }'>
+      <xs:choice>
+        <xs:sequence>
+          <xs:sequence dfdl:hiddenGroupRef="tns:PI_true_version_D1" />
+          <xs:element name="future_use_11" type="tns:future_use_group_type"/>
+        </xs:sequence>
+        <xs:sequence dfdl:hiddenGroupRef="tns:PI_false_version_D1" />
+      </xs:choice>
+      <xs:choice>
+        <xs:sequence>
+          <xs:sequence dfdl:hiddenGroupRef="tns:PI_true_version_D1" />
+          <xs:element name="future_use_12" type="tns:future_use_group_type"/>
+        </xs:sequence>
+        <xs:sequence dfdl:hiddenGroupRef="tns:PI_false_version_D1" />
+      </xs:choice>
+      <xs:choice>
+        <xs:sequence>
+          <xs:sequence dfdl:hiddenGroupRef="tns:PI_true_version_D1" />
+          <xs:element name="future_use_13" type="tns:future_use_group_type"/>
+        </xs:sequence>
+        <xs:sequence dfdl:hiddenGroupRef="tns:PI_false_version_D1" />
+      </xs:choice>
+      <xs:choice>
+        <xs:sequence>
+          <xs:sequence dfdl:hiddenGroupRef="tns:PI_true_version_D1" />
+          <xs:element name="future_use_14" type="tns:future_use_group_type"/>
+        </xs:sequence>
+        <xs:sequence dfdl:hiddenGroupRef="tns:PI_false_version_D1" />
+      </xs:choice>
+      <xs:choice>
+        <xs:sequence>
+          <xs:sequence dfdl:hiddenGroupRef="tns:PI_true_version_D1" />
+          <xs:element name="future_use_15" type="tns:future_use_group_type"/>
+        </xs:sequence>
+        <xs:sequence dfdl:hiddenGroupRef="tns:PI_false_version_D1" />
+      </xs:choice>
+    </xs:sequence>
+  </xs:group>
+  
+  <xs:complexType name="future_use_group_type">
+    <xs:sequence>
+      <xs:element name="group_size" type="tns:tIntField" dfdl:length="12" dfdl:outputValueCalc=" { (fn:count(../future_use_group_data/word) * 32) +   (fn:count(../future_use_group_data/partialWord) * dfdl:valueLength(../future_use_group_data/partialWord, 'bits')) }"/>
+      <!-- DFDL doesn't allow length units of 'bits' for xs:nonNegativeInteger, 
+           So we use an array of unsigned int, for this opaque region. -->
+      <xs:element name="future_use_group_data">
         <xs:complexType>
           <xs:sequence>
-            <xs:choice>
-              <xs:sequence>
-                <xs:sequence dfdl:hiddenGroupRef="msi:PI_true" />
-                <xs:element name="future_use_11" type="tns:future_use_group_type"
-                  dfdl:lengthKind="implicit" />
-              </xs:sequence>
-              <xs:sequence dfdl:hiddenGroupRef="msi:PI_false" />
-            </xs:choice>
-            <xs:choice>
-              <xs:sequence>
-                <xs:sequence dfdl:hiddenGroupRef="msi:PI_true" />
-                <xs:element name="future_use_12" type="tns:future_use_group_type"
-                  dfdl:lengthKind="implicit" />
-              </xs:sequence>
-              <xs:sequence dfdl:hiddenGroupRef="msi:PI_false" />
-            </xs:choice>
-            <xs:choice>
-              <xs:sequence>
-                <xs:sequence dfdl:hiddenGroupRef="msi:PI_true" />
-                <xs:element name="future_use_13" type="tns:future_use_group_type"
-                  dfdl:lengthKind="implicit" />
-              </xs:sequence>
-              <xs:sequence dfdl:hiddenGroupRef="msi:PI_false" />
-            </xs:choice>
-            <xs:choice>
-              <xs:sequence>
-                <xs:sequence dfdl:hiddenGroupRef="msi:PI_true" />
-                <xs:element name="future_use_14" type="tns:future_use_group_type"
-                  dfdl:lengthKind="implicit" />
-              </xs:sequence>
-              <xs:sequence dfdl:hiddenGroupRef="msi:PI_false" />
-            </xs:choice>
-            <xs:choice>
-              <xs:sequence>
-                <xs:sequence dfdl:hiddenGroupRef="msi:PI_true" />
-                <xs:element name="future_use_15" type="tns:future_use_group_type"
-                  dfdl:lengthKind="implicit" />
-              </xs:sequence>
-              <xs:sequence dfdl:hiddenGroupRef="msi:PI_false" />
-            </xs:choice>
+            <xs:element maxOccurs="128" minOccurs="0" name="word" type="tns:tIntField" dfdl:length="32" dfdl:occursCount="{ ../../group_size idiv 32 }" dfdl:occursCountKind="expression"/>
+            <xs:element maxOccurs="1" minOccurs="0" name="partialWord" type="tns:tIntField" dfdl:length="{ ../../group_size mod 32 }" dfdl:occursCount="{ if ((../../group_size mod 32) ne 0) then 1 else 0 }" dfdl:occursCountKind="expression"/>
           </xs:sequence>
         </xs:complexType>
       </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:group name="PI_true_version_D1">
+    <xs:sequence>
+      <xs:element name="PI_true_D1" type="msi:presenceIndicator" dfdl:outputValueCalc="{ 1 }">
+        <xs:annotation>
+          <xs:appinfo source="http://www.ogf.org/dfdl/">
+            <dfdl:discriminator test="{ (. eq 1) and ($tns:versionSpec eq 'D1')  }" />
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+
+  <xs:group name="PI_false_version_D1">
+    <xs:sequence>
+      <xs:element name="PI_false_D1" type="xs:unsignedInt"
+      dfdl:lengthKind="explicit" 
+      dfdl:length="{ if ($tns:versionSpec eq 'D1') then 1 else 0 }" 
+      dfdl:outputValueCalc="{ 0 }" />
     </xs:sequence>
   </xs:group>
   

--- a/src/test/resources/com/tresys/mil-std-2045/milstd2045.tdml
+++ b/src/test/resources/com/tresys/mil-std-2045/milstd2045.tdml
@@ -712,5 +712,301 @@ SOFTWARE.
     </tdml:dfdlInfoset>
   </tdml:infoset>
   </tdml:parserTestCase>
+
+  <tdml:parserTestCase 
+    name="test_2045_D1_minimum_size_header" 
+    root="milstd2045_application_header"
+    model="hdr" 
+    description='Smallest possible header'
+    roundTrip="none">
+    <tdml:document bitOrder="LSBFirst">
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[Version                       0100]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[FPI Data compression type        0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Originator address group     0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Recipient address group      0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Information address group    0]]></tdml:documentPart><!-- 8 -->
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[FPI header_size                  0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI future use One               0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI future use 2                 0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI future use 3                 0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI future use 4                 0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI future use 5                 0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GRI message handling group (last)0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[UMF                           0000]]></tdml:documentPart><!-- 16 -->
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[FPI message standard version     0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI vmf message ident group      0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[FPI file name                    0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[FPI message size                 0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[Operation Indicator             00]]></tdml:documentPart><!-- 24 -->
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[Retransmit Indicator             0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[Message Precendence Code       000]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[Security Classification         00]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[FPI C/R marking                  0]]></tdml:documentPart><!-- 32 -->
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Originator DTG               0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Perisability DTG             0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Acknowledgment Request grp   0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Response data group          0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Reference message data grp   0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Future use 6                 0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Future use 7                 0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Future use 8                 0]]></tdml:documentPart><!-- 40 -->
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Future use 9                 0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Future use Ten               0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Message Security group       0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Future use Eleven            0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Future use Twelve            0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Future use Thirteen          0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Future use Fourteen          0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Future use Fifteen           0]]></tdml:documentPart><!-- 48 -->
+    </tdml:document>
+
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:milstd2045_application_header>
+          <version>
+            <value>4</value>
+          </version>
+          <futureUseGroup1/>
+          <message_handling_group>
+            <umf>
+              <value>0</value>
+            </umf>
+            <operation_indicator>
+              <value>0</value>
+            </operation_indicator>
+            <retransmit_indicator>
+              <value>0</value>
+            </retransmit_indicator>
+            <message_precedence_codes>
+              <value>0</value>
+            </message_precedence_codes>
+            <security_classification>
+              <value>0</value>
+            </security_classification>
+            <futureUseGroup2/>
+          </message_handling_group>
+          <futureUseGroup3/>
+        </ex:milstd2045_application_header>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase 
+    name="test_2045_C_minimum_size_header" 
+    root="milstd2045_application_header"
+    model="hdr" 
+    description='Smallest possible header'
+    roundTrip="none">
+    <tdml:document bitOrder="LSBFirst">
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[Version                       0010]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[FPI Data compression type        0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Originator address group     0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Recipient address group      0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Information address group    0]]></tdml:documentPart><!-- 8 -->
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[FPI header_size                  0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GRI message handling group (last)0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[UMF                           0000]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[FPI message standard version     0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI vmf message ident group      0]]></tdml:documentPart><!-- 16 -->
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[FPI file name                    0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[FPI message size                 0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[Operation Indicator             00]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[Retransmit Indicator             0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[Message Precendence Code       000]]></tdml:documentPart><!-- ends at 24 -->
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[Security Classification         00]]></tdml:documentPart><!-- 25 -->
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[FPI C/R marking                  0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Originator DTG               0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Perisability DTG             0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Acknowledgment Request grp   0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Response data group          0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Reference message data grp   0]]></tdml:documentPart><!-- 32 -->
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Message Security group       0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[Padding                    0000000]]></tdml:documentPart><!-- 40 -->
+    </tdml:document>
+
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:milstd2045_application_header>
+          <version>
+            <value>2</value>
+          </version>
+          <message_handling_group>
+            <umf>
+              <value>0</value>
+            </umf>
+            <operation_indicator>
+              <value>0</value>
+            </operation_indicator>
+            <retransmit_indicator>
+              <value>0</value>
+            </retransmit_indicator>
+            <message_precedence_codes>
+              <value>0</value>
+            </message_precedence_codes>
+            <security_classification>
+              <value>0</value>
+            </security_classification>
+          </message_handling_group>
+        </ex:milstd2045_application_header>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+
+
+  <tdml:parserTestCase 
+    name="test_2045_D1_control_release_marking1" 
+    root="milstd2045_application_header"
+    model="hdr" 
+    description='Exercises the control_release_marking_D1  element which is inside a choice.'>
+    <tdml:document bitOrder="LSBFirst">
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[Version                       0100]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[FPI Data compression type        0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Originator address group     0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Recipient address group      0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Information address group    0]]></tdml:documentPart><!-- 8 -->
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[FPI header_size                  0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI future use One               0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI future use 2                 0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI future use 3                 0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI future use 4                 0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI future use 5                 0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GRI message handling group (last)0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[UMF                          000 0]]></tdml:documentPart><!-- 16 -->
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[FPI message standard version     0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI vmf message ident group      0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[FPI file name                    0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[FPI message size                 0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[Operation Indicator             00]]></tdml:documentPart><!-- 24 -->
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[Retransmit Indicator             0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[Message Precendence Code       000]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[Security Classification         00]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[FPI C/R marking                  1]]></tdml:documentPart><!-- 32 -->
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[FRI C/R Marking (Last)           0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[C/R Marking             00000 0000]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Originator DTG               0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Perisability DTG             0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Acknowledgment Request grp   0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Response data group          0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Reference message data grp   0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Future use 6                 0]]></tdml:documentPart><!-- 48 -->
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Future use 7                 0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Future use 8                 0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Future use 9                 0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Future use Ten               0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Message Security group       0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Future use Eleven            0]]></tdml:documentPart><!-- 54 -->
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Future use Twelve            0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Future use Thirteen          0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Future use Fourteen          0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Future use Fifteen           0]]></tdml:documentPart><!-- 58 -->
+      
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[Padding                     000000]]></tdml:documentPart><!-- 64 -->
+      
+    </tdml:document>
+
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:milstd2045_application_header>
+          <version>
+            <value>4</value>
+          </version>
+          <futureUseGroup1/>
+          <message_handling_group>
+            <umf>
+              <value>0</value>
+            </umf>
+            <operation_indicator>
+              <value>0</value>
+            </operation_indicator>
+            <retransmit_indicator>
+              <value>0</value>
+            </retransmit_indicator>
+            <message_precedence_codes>
+              <value>0</value>
+            </message_precedence_codes>
+            <security_classification>
+              <value>0</value>
+            </security_classification>
+            <control_release_marking_D1>
+              <value>0</value>
+            </control_release_marking_D1>
+            <futureUseGroup2/>
+          </message_handling_group>
+          <futureUseGroup3/>
+        </ex:milstd2045_application_header>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+  
+    <tdml:parserTestCase 
+    name="test_2045_C_control_release_marking1" 
+    root="milstd2045_application_header"
+    model="hdr" 
+    description='Exercises the control_release_marking_D1  element which is inside a choice.'>
+    <tdml:document bitOrder="LSBFirst">
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[Version                       0010]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[FPI Data compression type        0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Originator address group     0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Recipient address group      0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Information address group    0]]></tdml:documentPart><!-- 8 -->
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[FPI header_size                  0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GRI message handling group (last)0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[UMF                          000 0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[FPI message standard version     0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI vmf message ident group      0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[FPI file name                    0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[FPI message size                 0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[Operation Indicator             00]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[Retransmit Indicator             0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[Message Precendence Code       000]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[Security Classification         00]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[FPI C/R marking                  1]]></tdml:documentPart>
+      <tdml:documentPart type="text" 
+        encoding="X-DFDL-US-ASCII-7-BIT-PACKED"
+        bitOrder="LSBFirst" replaceDFDLEntities="true"><![CDATA[MARKING%DEL;]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Originator DTG               0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Perisability DTG             0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Acknowledgment Request grp   0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Response data group          0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Reference message data grp   0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Message Security group       0]]></tdml:documentPart>
+      
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[Padding                    0000000]]></tdml:documentPart>
+      
+    </tdml:document>
+
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:milstd2045_application_header>
+          <version>
+            <value>2</value>
+          </version>
+          <message_handling_group>
+            <umf>
+              <value>0</value>
+            </umf>
+            <operation_indicator>
+              <value>0</value>
+            </operation_indicator>
+            <retransmit_indicator>
+              <value>0</value>
+            </retransmit_indicator>
+            <message_precedence_codes>
+              <value>0</value>
+            </message_precedence_codes>
+            <security_classification>
+              <value>0</value>
+            </security_classification>
+            <control_release_marking_C>
+              <value>MARKING</value>
+            </control_release_marking_C>
+          </message_handling_group>
+        </ex:milstd2045_application_header>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+  
+
 </tdml:testSuite>
 

--- a/src/test/resources/com/tresys/mil-std-2045/milstd2045.tdml
+++ b/src/test/resources/com/tresys/mil-std-2045/milstd2045.tdml
@@ -32,7 +32,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE
 SOFTWARE.
 -->
 <tdml:testSuite suiteName="MIL_STD_2045_Unit_Tests" description="Unit tests"
-  xmlns:tns="http://example.com"
   xmlns:ms="urn:milstd2045DFDL"
   xmlns:msi="urn:milstd2045DFDLInternal"
   xmlns:tdml="http://www.ibm.com/xmlns/dfdl/testData" 
@@ -275,7 +274,6 @@ SOFTWARE.
               <value>3</value>
             </urn>
           </recipient_address_group>
-          <futureUseGroup1/>
           <message_handling_group>
             <umf>
               <value>2</value>
@@ -331,9 +329,7 @@ SOFTWARE.
                 <value>0</value>
               </operator_reply_request_indicator>
             </acknowledgement_request_group>
-            <futureUseGroup2/>
           </message_handling_group>
-          <futureUseGroup3/>
         </milstd2045_application_header>
       </tdml:dfdlInfoset>
     </tdml:infoset>
@@ -419,7 +415,6 @@ SOFTWARE.
           <header_size>
             <value>9</value>
           </header_size>
-          <futureUseGroup1/>
           <message_handling_group>
             <umf>
               <value>15</value>
@@ -439,9 +434,7 @@ SOFTWARE.
             <security_classification>
               <value>3</value>
             </security_classification>
-            <futureUseGroup2/>
           </message_handling_group>
-          <futureUseGroup3/>
         </milstd2045_application_header>
       </tdml:dfdlInfoset>
     </tdml:infoset>
@@ -717,8 +710,7 @@ SOFTWARE.
     name="test_2045_D1_minimum_size_header" 
     root="milstd2045_application_header"
     model="hdr" 
-    description='Smallest possible header'
-    roundTrip="none">
+    description='Smallest possible header'>
     <tdml:document bitOrder="LSBFirst">
       <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[Version                       0100]]></tdml:documentPart>
       <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[FPI Data compression type        0]]></tdml:documentPart>
@@ -766,7 +758,6 @@ SOFTWARE.
           <version>
             <value>4</value>
           </version>
-          <futureUseGroup1/>
           <message_handling_group>
             <umf>
               <value>0</value>
@@ -783,9 +774,7 @@ SOFTWARE.
             <security_classification>
               <value>0</value>
             </security_classification>
-            <futureUseGroup2/>
           </message_handling_group>
-          <futureUseGroup3/>
         </ex:milstd2045_application_header>
       </tdml:dfdlInfoset>
     </tdml:infoset>
@@ -795,8 +784,7 @@ SOFTWARE.
     name="test_2045_C_minimum_size_header" 
     root="milstd2045_application_header"
     model="hdr" 
-    description='Smallest possible header'
-    roundTrip="none">
+    description='Smallest possible header'>
     <tdml:document bitOrder="LSBFirst">
       <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[Version                       0010]]></tdml:documentPart>
       <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[FPI Data compression type        0]]></tdml:documentPart>
@@ -911,7 +899,6 @@ SOFTWARE.
           <version>
             <value>4</value>
           </version>
-          <futureUseGroup1/>
           <message_handling_group>
             <umf>
               <value>0</value>
@@ -931,19 +918,109 @@ SOFTWARE.
             <control_release_marking_D1>
               <value>0</value>
             </control_release_marking_D1>
-            <futureUseGroup2/>
           </message_handling_group>
-          <futureUseGroup3/>
         </ex:milstd2045_application_header>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
   
-    <tdml:parserTestCase 
-    name="test_2045_C_control_release_marking1" 
+  <tdml:parserTestCase 
+    name="test_2045_D1_control_release_marking2" 
     root="milstd2045_application_header"
     model="hdr" 
     description='Exercises the control_release_marking_D1  element which is inside a choice.'>
+    <tdml:document bitOrder="LSBFirst">
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[Version                       0100]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[FPI Data compression type        0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Originator address group     0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Recipient address group      0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Information address group    0]]></tdml:documentPart><!-- 8 -->
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[FPI header_size                  0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI future use One               0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI future use 2                 0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI future use 3                 0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI future use 4                 0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI future use 5                 0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GRI message handling group (last)0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[UMF                          000 0]]></tdml:documentPart><!-- 16 -->
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[FPI message standard version     0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI vmf message ident group      0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[FPI file name                    0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[FPI message size                 0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[Operation Indicator             00]]></tdml:documentPart><!-- 24 -->
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[Retransmit Indicator             0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[Message Precendence Code       000]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[Security Classification         00]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[FPI C/R marking                  1]]></tdml:documentPart><!-- 32 -->
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[FRI C/R Marking (not Last)       1]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[C/R Marking             00000 0001]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[FRI C/R Marking (not Last)       1]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[C/R Marking             00000 0010]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[FRI C/R Marking (Last)           0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[C/R Marking             00000 0011]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Originator DTG               0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Perisability DTG             0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Acknowledgment Request grp   0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Response data group          0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Reference message data grp   0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Future use 6                 0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Future use 7                 0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Future use 8                 0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Future use 9                 0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Future use Ten               0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Message Security group       0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Future use Eleven            0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Future use Twelve            0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Future use Thirteen          0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Future use Fourteen          0]]></tdml:documentPart>
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[GPI Future use Fifteen           0]]></tdml:documentPart><!-- 58 -->
+      
+      <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[Padding                     00]]></tdml:documentPart><!-- 64 -->
+      
+    </tdml:document>
+
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:milstd2045_application_header>
+          <version>
+            <value>4</value>
+          </version>
+          <message_handling_group>
+            <umf>
+              <value>0</value>
+            </umf>
+            <operation_indicator>
+              <value>0</value>
+            </operation_indicator>
+            <retransmit_indicator>
+              <value>0</value>
+            </retransmit_indicator>
+            <message_precedence_codes>
+              <value>0</value>
+            </message_precedence_codes>
+            <security_classification>
+              <value>0</value>
+            </security_classification>
+            <control_release_marking_D1>
+              <value>1</value>
+            </control_release_marking_D1>
+            <control_release_marking_D1>
+              <value>2</value>
+            </control_release_marking_D1>
+            <control_release_marking_D1>
+              <value>3</value>
+            </control_release_marking_D1>
+          </message_handling_group>
+        </ex:milstd2045_application_header>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+  
+  <tdml:parserTestCase 
+    name="test_2045_C_control_release_marking1" 
+    root="milstd2045_application_header"
+    model="hdr" 
+    description='Exercises the control_release_marking_C  element which is inside a choice.'>
     <tdml:document bitOrder="LSBFirst">
       <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[Version                       0010]]></tdml:documentPart>
       <tdml:documentPart type="bits" bitOrder="LSBFirst" byteOrder="RTL"><![CDATA[FPI Data compression type        0]]></tdml:documentPart>

--- a/src/test/scala/com/tresys/mil_std_2045/Test2045Hdr.scala
+++ b/src/test/scala/com/tresys/mil_std_2045/Test2045Hdr.scala
@@ -74,6 +74,10 @@ class Test2045Hdr {
     runner.runOneTest("test_2045_D1_control_release_marking1")
   }
 
+  @Test def test_2045_D1_control_release_marking2() {
+    runner.runOneTest("test_2045_D1_control_release_marking2")
+  }
+
   @Test def test_2045_C_control_release_marking1() {
     runner.runOneTest("test_2045_C_control_release_marking1")
   }

--- a/src/test/scala/com/tresys/mil_std_2045/Test2045Hdr.scala
+++ b/src/test/scala/com/tresys/mil_std_2045/Test2045Hdr.scala
@@ -61,4 +61,20 @@ class Test2045Hdr {
   @Test def test_2045_C_msghdr2() {
     runner.runOneTest("test_2045_C_msghdr2")
   }
+
+  @Test def test_2045_D1_minimum_size_header() {
+    runner.runOneTest("test_2045_D1_minimum_size_header")
+  }
+
+  @Test def test_2045_C_minimum_size_header() {
+    runner.runOneTest("test_2045_C_minimum_size_header")
+  }
+
+  @Test def test_2045_D1_control_release_marking1() {
+    runner.runOneTest("test_2045_D1_control_release_marking1")
+  }
+
+  @Test def test_2045_C_control_release_marking1() {
+    runner.runOneTest("test_2045_C_control_release_marking1")
+  }
 }


### PR DESCRIPTION
Version 0.0.6

Fixes 2 tickets 

Eliminates the empty <futureUseGroup1/> type elements that are otherwise
annoying in the D1-version schema. 
https://github.com/DFDLSchemas/mil-std-2045/issues/8
(This issue requires that test data for schemas that incorporate this
one such as VMF, be updated.)

Asserts that payload is uncompresed.
https://github.com/DFDLSchemas/mil-std-2045/issues/1

