### PR TITLE
Fix name collision on vmf vs. xml_vmf field.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ version := "1.0.3"
 scalaVersion := "2.12.15"
 
 libraryDependencies ++= Seq(
-  "org.apache.daffodil" %% "daffodil-tdml-processor" % "3.4.0-SNAPSHOT" % "test",
+  "org.apache.daffodil" %% "daffodil-tdml-processor" % "3.3.0" % "test",
   "junit" % "junit" % "4.13.2" % "test",
   "com.github.sbt" % "junit-interface" % "0.13.2" % "test"
 )

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ version := "1.0.3"
 scalaVersion := "2.12.15"
 
 libraryDependencies ++= Seq(
-  "org.apache.daffodil" %% "daffodil-tdml-processor" % "3.3.0" % "test",
+  "org.apache.daffodil" %% "daffodil-tdml-processor" % "3.4.0-SNAPSHOT" % "test",
   "junit" % "junit" % "4.13.2" % "test",
   "com.github.sbt" % "junit-interface" % "0.13.2" % "test"
 )

--- a/src/main/resources/com/owlcyberdefense/mil-std-2045/xsd/milstd2045.enums.dfdl.xsd
+++ b/src/main/resources/com/owlcyberdefense/mil-std-2045/xsd/milstd2045.enums.dfdl.xsd
@@ -377,7 +377,7 @@ SOFTWARE.
   <group name="messageStandardVersionXMLVMFGroup">
     <sequence>
       <group ref="tns:h_messageStandardVersionXMLVMFGroup"/>
-      <element name="vmf" type="xs:string"
+      <element name="xml_vmf" type="xs:string"
                dfdl:inputValueCalc="{
               if (fn:exists(../vmf_hdr_C)) then ../vmf_hdr_C else ../vmf_hdr_D1
               }"/>

--- a/src/test/scala/com/owlcyberdefense/mil_std_2045/Test2045Hdr.scala
+++ b/src/test/scala/com/owlcyberdefense/mil_std_2045/Test2045Hdr.scala
@@ -1,14 +1,12 @@
 package com.owlcyberdefense.mil_std_2045
 import org.junit.Test
 import org.apache.daffodil.tdml.DFDLTestSuite
+import org.apache.daffodil.tdml.Runner
 import org.apache.daffodil.util.Misc
 
 object Test2045Hdr {
   val testDir = "com/owlcyberdefense/mil-std-2045/"
-  val aa = testDir + "milstd2045.tdml"
-  val validateTDML = true
-  val validateDFDLSchema = true
-  lazy val runner = new DFDLTestSuite(Misc.getRequiredResource(aa), validateTDML, validateDFDLSchema)
+  lazy val runner = Runner(testDir, "milstd2045.tdml")
 }
 
 class Test2045Hdr {


### PR DESCRIPTION
Update to 3.4.0-SNAPSHOT of daffodil

Fix TDML test to use Runner API.