### PR TITLE
Adds test back to show bug-28 (unparser deadlock) is fixed

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,12 +2,12 @@ name := "dfdl-mil-std-2045"
 
 organization := "com.owlcyberdefense"
 
-version := "1.0.4"
+version := "1.0.5-SNAPSHOT"
 
 scalaVersion := "2.12.15"
 
 libraryDependencies ++= Seq(
-  "org.apache.daffodil" %% "daffodil-tdml-processor" % "3.3.0" % "test",
+  "org.apache.daffodil" %% "daffodil-tdml-processor" % "3.4.0-SNAPSHOT" % "test",
   "junit" % "junit" % "4.13.2" % "test",
   "com.github.sbt" % "junit-interface" % "0.13.2" % "test",
   "org.apache.logging.log4j" % "log4j-core" % "2.18.0" % "test"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.2
+sbt.version=1.7.1

--- a/src/test/scala/com/owlcyberdefense/mil_std_2045/Test2045Hdr.scala
+++ b/src/test/scala/com/owlcyberdefense/mil_std_2045/Test2045Hdr.scala
@@ -108,12 +108,8 @@ class Test2045Hdr {
     runner.runOneTest("test_2045_D1_all_fields_x2p")
   }
 
-  // Gets SuspensionDeadlockException on Daffodil 3.3.0
-  // This is just XML for two messages in a row. One message parses/unparses round trip
-  // in test_2045_D1_all_fields. But two (of the same) message in a row parses properly
-  // per test_2045_D1_all_fields_x2p, but the resulting XML document does not unparse. 
-  // @Test
-  def test_2045_D1_all_fields_x2u() {
+  // Requires Daffodil 3.4.0 (or a version newer than git hash bd46fd
+  @Test def test_2045_D1_all_fields_x2u() {
     runner.runOneTest("test_2045_D1_all_fields_x2u")
   }
 


### PR DESCRIPTION
dev branch, and this remains a snapshot version until daffodil 3.4.0 is released. 