### PR TITLE
Fix for #36 - message_precedence_codes - different enums for C and D1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "dfdl-mil-std-2045"
 
 organization := "com.owlcyberdefense"
 
-version := "1.0.4"
+version := "1.0.6-SNAPSHOT"
 
 scalaVersion := "2.12.15"
 

--- a/src/main/resources/com/owlcyberdefense/mil-std-2045/xsd/milstd2045.enums.dfdl.xsd
+++ b/src/main/resources/com/owlcyberdefense/mil-std-2045/xsd/milstd2045.enums.dfdl.xsd
@@ -550,7 +550,58 @@ SOFTWARE.
     </restriction>
   </simpleType>
 
-  <simpleType name="messagePrecedenceEnum" dfdlx:repType="tns:enum3">
+  <group name="h_messagePrecedenceCodesGroup">
+    <choice dfdl:choiceDispatchKey="{ $tns:versionSpec }">
+      <!--
+      DFDL has no way to discriminate a choice at unparse time
+      based on data values in the infoset. So choices really cannot
+      be in hidden groups unless the first branch is acceptable as a default.
+
+      Hence, this group cannot be hidden.
+      -->
+      <element name="vmf_hdr_C" dfdl:choiceBranchKey="C"
+               type="tns:messagePrecedenceCodesEnum_C"/>
+      <element name="vmf_hdr_D1" dfdl:choiceBranchKey="D1"
+               type="tns:messagePrecedenceCodesEnum_D"/>
+    </choice>
+  </group>
+
+  <group name="messagePrecedenceCodesGroup">
+    <sequence>
+      <group ref="tns:h_messagePrecedenceCodesGroup"/>
+      <element name="value" type="xs:string"
+               dfdl:inputValueCalc="{
+              if (fn:exists(../vmf_hdr_C)) then ../vmf_hdr_C else ../vmf_hdr_D1
+              }"/>
+    </sequence>
+  </group>
+
+  <simpleType name="messagePrecedenceCodesEnum_C" dfdlx:repType="tns:enum3">
+    <restriction base="tns:enumString">
+      <enumeration value="OK_Emergency" dfdlx:repValues="2"/>
+      <enumeration value="OK_Flash" dfdlx:repValues="4"/>
+      <enumeration value="OK_Immediate" dfdlx:repValues="5"/>
+      <enumeration value="OK_Priority" dfdlx:repValues="6"/>
+      <enumeration value="OK_Routine" dfdlx:repValues="7"/>
+
+      <!--
+      This pattern facet insures that only the above "OK" values are
+      considered valid.
+      -->
+      <pattern value="OK_.*"/>
+      <!--
+      The remaining enums don't have OK_ prefixes, so will be
+      considered well-formed, but won't pass validation, as
+      both the pattern AND one of the enumerations must be
+      satisfied.
+      -->
+      <enumeration value="Reserved_0" dfdlx:repValues="0"/>
+      <enumeration value="Reserved_1" dfdlx:repValues="1"/>
+      <enumeration value="Reserved_3" dfdlx:repValues="3"/>
+    </restriction>
+  </simpleType>
+
+  <simpleType name="messagePrecedenceCodesEnum_D" dfdlx:repType="tns:enum3">
     <restriction base="tns:enumString">
       <enumeration value="OK_Routine" dfdlx:repValues="0"/>
       <enumeration value="OK_Priority" dfdlx:repValues="1"/>

--- a/src/main/resources/com/owlcyberdefense/mil-std-2045/xsd/milstd2045_application_header.dfdl.xsd
+++ b/src/main/resources/com/owlcyberdefense/mil-std-2045/xsd/milstd2045_application_header.dfdl.xsd
@@ -250,13 +250,15 @@ SOFTWARE.
                               </sequence>
                             </complexType>
                           </element>
+
                           <element name="message_precedence_codes">
                             <complexType>
                               <sequence>
-                                <element name="value" type="tns:messagePrecedenceEnum"/>
+                                <group ref="tns:messagePrecedenceCodesGroup"/>
                               </sequence>
                             </complexType>
                           </element>
+                          
                           <element name="security_classification">
                             <complexType>
                               <sequence>

--- a/src/test/resources/com/owlcyberdefense/mil-std-2045/D1_all_fields.x2.xml
+++ b/src/test/resources/com/owlcyberdefense/mil-std-2045/D1_all_fields.x2.xml
@@ -83,6 +83,7 @@
               <value>Original_Message</value>
             </retransmit_indicator>
             <message_precedence_codes>
+              <vmf_hdr_D1>OK_Immediate</vmf_hdr_D1>
               <value>OK_Immediate</value>
             </message_precedence_codes>
             <security_classification>
@@ -237,6 +238,7 @@
               <value>Original_Message</value>
             </retransmit_indicator>
             <message_precedence_codes>
+              <vmf_hdr_D1>OK_Immediate</vmf_hdr_D1>
               <value>OK_Immediate</value>
             </message_precedence_codes>
             <security_classification>
@@ -453,6 +455,7 @@
               <value>Original_Message</value>
             </retransmit_indicator>
             <message_precedence_codes>
+              <vmf_hdr_D1>OK_Immediate</vmf_hdr_D1>
               <value>OK_Immediate</value>
             </message_precedence_codes>
             <security_classification>
@@ -607,6 +610,7 @@
               <value>Original_Message</value>
             </retransmit_indicator>
             <message_precedence_codes>
+              <vmf_hdr_D1>OK_Immediate</vmf_hdr_D1>
               <value>OK_Immediate</value>
             </message_precedence_codes>
             <security_classification>

--- a/src/test/resources/com/owlcyberdefense/mil-std-2045/D1_all_fields.xml
+++ b/src/test/resources/com/owlcyberdefense/mil-std-2045/D1_all_fields.xml
@@ -83,6 +83,7 @@
               <value>Original_Message</value>
             </retransmit_indicator>
             <message_precedence_codes>
+              <vmf_hdr_D1>OK_Immediate</vmf_hdr_D1>
               <value>OK_Immediate</value>
             </message_precedence_codes>
             <security_classification>
@@ -237,6 +238,7 @@
               <value>Original_Message</value>
             </retransmit_indicator>
             <message_precedence_codes>
+              <vmf_hdr_D1>OK_Immediate</vmf_hdr_D1>
               <value>OK_Immediate</value>
             </message_precedence_codes>
             <security_classification>
@@ -371,4 +373,3 @@
     </header>
   </message>
 </mst:milstd2045_messages>
-

--- a/src/test/resources/com/owlcyberdefense/mil-std-2045/milstd2045.tdml
+++ b/src/test/resources/com/owlcyberdefense/mil-std-2045/milstd2045.tdml
@@ -320,6 +320,7 @@ SOFTWARE.
                   <value>Original_Message</value>
                 </retransmit_indicator>
                 <message_precedence_codes>
+                  <vmf_hdr_D1>OK_Immediate</vmf_hdr_D1>
                   <value>OK_Immediate</value>
                 </message_precedence_codes>
                 <security_classification>
@@ -402,6 +403,7 @@ SOFTWARE.
                   <value>Original_Message</value>
                 </retransmit_indicator>
                 <message_precedence_codes>
+                  <vmf_hdr_D1>OK_Immediate</vmf_hdr_D1>
                   <value>OK_Immediate</value>
                 </message_precedence_codes>
                 <security_classification>
@@ -498,6 +500,7 @@ operator_reply_request_indicator set to 1">
                   <value>Original_Message</value>
                 </retransmit_indicator>
                 <message_precedence_codes>
+                  <vmf_hdr_D1>OK_Immediate</vmf_hdr_D1>
                   <value>OK_Immediate</value>
                 </message_precedence_codes>
                 <security_classification>
@@ -639,6 +642,7 @@ operator_reply_request_indicator set to 1">
                   <value>Retransmitted_Message</value>
                 </retransmit_indicator>
                 <message_precedence_codes>
+                  <vmf_hdr_D1>Reserved_7</vmf_hdr_D1>
                   <value>Reserved_7</value>
                 </message_precedence_codes>
                 <security_classification>
@@ -718,7 +722,8 @@ operator_reply_request_indicator set to 1">
                   <value>Original_Message</value>
                 </retransmit_indicator>
                 <message_precedence_codes>
-                  <value>OK_Flash_Override</value>
+                  <vmf_hdr_C>OK_Flash</vmf_hdr_C>
+                  <value>OK_Flash</value>
                 </message_precedence_codes>
                 <security_classification>
                   <value>U</value>
@@ -801,7 +806,8 @@ operator_reply_request_indicator set to 1">
                   <value>Original_Message</value>
                 </retransmit_indicator>
                 <message_precedence_codes>
-                  <value>OK_Flash_Override</value>
+                  <vmf_hdr_C>OK_Flash</vmf_hdr_C>
+                  <value>OK_Flash</value>
                 </message_precedence_codes>
                 <security_classification>
                   <value>U</value>
@@ -900,7 +906,8 @@ operator_reply_request_indicator set to 1">
                   <value>Original_Message</value>
                 </retransmit_indicator>
                 <message_precedence_codes>
-                  <value>OK_Flash_Override</value>
+                  <vmf_hdr_C>OK_Flash</vmf_hdr_C>
+                  <value>OK_Flash</value>
                 </message_precedence_codes>
                 <security_classification>
                   <value>U</value>
@@ -1079,7 +1086,8 @@ operator_reply_request_indicator set to 1">
                   <value>Original_Message</value>
                 </retransmit_indicator>
                 <message_precedence_codes>
-                  <value>OK_Immediate</value>
+                  <vmf_hdr_C>OK_Emergency</vmf_hdr_C>
+                  <value>OK_Emergency</value>
                 </message_precedence_codes>
                 <security_classification>
                   <value>U</value>
@@ -1213,6 +1221,7 @@ operator_reply_request_indicator set to 1">
                   <value>Original_Message</value>
                 </retransmit_indicator>
                 <message_precedence_codes>
+                  <vmf_hdr_D1>OK_Routine</vmf_hdr_D1>
                   <value>OK_Routine</value>
                 </message_precedence_codes>
                 <security_classification>
@@ -1303,7 +1312,8 @@ operator_reply_request_indicator set to 1">
                   <value>Original_Message</value>
                 </retransmit_indicator>
                 <message_precedence_codes>
-                  <value>OK_Routine</value>
+                  <vmf_hdr_C>Reserved_0</vmf_hdr_C>
+                  <value>Reserved_0</value>
                 </message_precedence_codes>
                 <security_classification>
                   <value>U</value>
@@ -1314,6 +1324,10 @@ operator_reply_request_indicator set to 1">
         </ex:milstd2045_application_header>
       </tdml:dfdlInfoset>
     </infoset>
+    <validationErrors>
+      <error>Reserved_0</error>
+      <error>vmf_hdr_C</error>
+    </validationErrors>
   </parserTestCase>
 
 
@@ -1429,6 +1443,7 @@ operator_reply_request_indicator set to 1">
                   <value>Original_Message</value>
                 </retransmit_indicator>
                 <message_precedence_codes>
+                  <vmf_hdr_D1>OK_Routine</vmf_hdr_D1>
                   <value>OK_Routine</value>
                 </message_precedence_codes>
                 <security_classification>
@@ -1569,6 +1584,7 @@ operator_reply_request_indicator set to 1">
                   <value>Original_Message</value>
                 </retransmit_indicator>
                 <message_precedence_codes>
+                  <vmf_hdr_D1>OK_Routine</vmf_hdr_D1>
                   <value>OK_Routine</value>
                 </message_precedence_codes>
                 <security_classification>
@@ -1675,7 +1691,8 @@ operator_reply_request_indicator set to 1">
                   <value>Original_Message</value>
                 </retransmit_indicator>
                 <message_precedence_codes>
-                  <value>OK_Routine</value>
+                  <vmf_hdr_C>Reserved_0</vmf_hdr_C>
+                  <value>Reserved_0</value>
                 </message_precedence_codes>
                 <security_classification>
                   <value>U</value>
@@ -1689,6 +1706,10 @@ operator_reply_request_indicator set to 1">
         </ex:milstd2045_application_header>
       </tdml:dfdlInfoset>
     </infoset>
+    <validationErrors>
+      <error>Reserved_0</error>
+      <error>vmf_hdr_C</error>
+    </validationErrors>
   </parserTestCase>
 
   <parserTestCase
@@ -1789,7 +1810,8 @@ operator_reply_request_indicator set to 1">
                   <value>Original_Message</value>
                 </retransmit_indicator>
                 <message_precedence_codes>
-                  <value>OK_Routine</value>
+                  <vmf_hdr_C>Reserved_0</vmf_hdr_C>
+                  <value>Reserved_0</value>
                 </message_precedence_codes>
                 <security_classification>
                   <value>U</value>
@@ -1873,4 +1895,3 @@ operator_reply_request_indicator set to 1">
   </unparserTestCase>
 
 </testSuite>
-


### PR DESCRIPTION
Updated values for this field in rev C test files to use the rev C enum mappings:
	Routine to Reserved_0
	Immediate to Emergency
	FlashOverride to Flash

Bumped version number in build.sbt

Reserved_0 causes a validation error. Added this as an expected validation error in the test case.

https://github.com/DFDLSchemas/mil-std-2045/issues/36