### PR TITLE
Version 1.1.0 - Remove all unbounded maxOccurs and regex.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,15 +2,15 @@ name := "dfdl-mil-std-2045"
 
 organization := "com.owlcyberdefense"
 
-version := "1.0.9"
+version := "1.1.0"
 
-scalaVersion := "2.12.15"
+scalaVersion := "2.12.17"
 
 libraryDependencies ++= Seq(
   "org.apache.daffodil" %% "daffodil-tdml-processor" % "3.4.0" % "test",
   "junit" % "junit" % "4.13.2" % "test",
-  "com.github.sbt" % "junit-interface" % "0.13.2" % "test",
-  "org.apache.logging.log4j" % "log4j-core" % "2.18.0" % "test"
+  "com.github.sbt" % "junit-interface" % "0.13.3" % "test",
+  "org.apache.logging.log4j" % "log4j-core" % "2.19.0" % "test"
 )
 
 testOptions += Tests.Argument(TestFrameworks.JUnit, "-v")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.1
+sbt.version=1.8.2

--- a/src/main/resources/com/owlcyberdefense/mil-std-2045/xsd/milstd2045.common.dfdl.xsd
+++ b/src/main/resources/com/owlcyberdefense/mil-std-2045/xsd/milstd2045.common.dfdl.xsd
@@ -85,7 +85,7 @@ SOFTWARE.
   <complexType name="address_group_type">
     <sequence>
       <element name="item"
-               minOccurs="1" maxOccurs="unbounded"
+               minOccurs="1" maxOccurs="16"
                dfdl:occursCountKind="implicit">
         <complexType>
           <sequence>

--- a/src/main/resources/com/owlcyberdefense/mil-std-2045/xsd/milstd2045.enums.dfdl.xsd
+++ b/src/main/resources/com/owlcyberdefense/mil-std-2045/xsd/milstd2045.enums.dfdl.xsd
@@ -135,7 +135,7 @@ SOFTWARE.
     <restriction base="tns:enumString">
       <enumeration value="LZW" dfdlx:repValues="0"/>
       <enumeration value="GZIP" dfdlx:repValues="1"/>
-      <pattern value="OK_*"/><!-- none of these are implemented yet -->
+      <pattern value="OK_.{0,20}"/><!-- none of these are implemented yet -->
     </restriction>
   </simpleType>
 
@@ -154,7 +154,7 @@ SOFTWARE.
       This pattern facet insures that only the above "OK" values are
       considered valid.
       -->
-      <pattern value="OK_.*"/>
+      <pattern value="OK_.{0,20}"/>
       <!--
       The remaining enums don't have OK_ prefixes, so will be
       considered well-formed, but won't pass validation, as
@@ -242,7 +242,7 @@ SOFTWARE.
       <enumeration value="Reserved_13" dfdlx:repValues="13"/>
       <enumeration value="Reserved_14" dfdlx:repValues="14"/>
       <enumeration value="Reserved_15" dfdlx:repValues="15"/>
-      <pattern value="OK_.*"/>
+      <pattern value="OK_.{0,20}"/>
     </restriction>
   </simpleType>
 
@@ -270,7 +270,7 @@ SOFTWARE.
       <enumeration value="Reserved_13" dfdlx:repValues="13"/>
       <enumeration value="Reserved_14" dfdlx:repValues="14"/>
       <enumeration value="Reserved_15" dfdlx:repValues="15"/>
-      <pattern value="OK_.*"/>
+      <pattern value="OK_.{0,20}"/>
     </restriction>
   </simpleType>
 
@@ -282,7 +282,7 @@ SOFTWARE.
       This pattern facet insures that only the above "OK" values are
       considered valid.
       -->
-      <pattern value="OK_.*"/>
+      <pattern value="OK_.{0,20}"/>
       <!--
       The remaining enums don't have OK_ prefixes, so will be
       considered well-formed, but won't pass validation, as
@@ -340,7 +340,7 @@ SOFTWARE.
       This pattern facet insures that only the above "OK" values are
       considered valid.
       -->
-      <pattern value="OK_.*"/>
+      <pattern value="OK_.{0,20}"/>
       <!--
       The remaining enums don't have OK_ prefixes, so will be
       considered well-formed, but won't pass validation, as
@@ -412,7 +412,7 @@ SOFTWARE.
       <enumeration value="Reserved_13" dfdlx:repValues="13"/>
       <enumeration value="Reserved_14" dfdlx:repValues="14"/>
       <enumeration value="Reserved_15" dfdlx:repValues="15"/>
-      <pattern value="OK_.*"/>
+      <pattern value="OK_.{0,20}"/>
     </restriction>
   </simpleType>
 
@@ -438,7 +438,7 @@ SOFTWARE.
       <enumeration value="Reserved_13" dfdlx:repValues="13"/>
       <enumeration value="Reserved_14" dfdlx:repValues="14"/>
       <enumeration value="Reserved_15" dfdlx:repValues="15"/>
-      <pattern value="OK_.*"/>
+      <pattern value="OK_.{0,20}"/>
     </restriction>
   </simpleType>
 
@@ -495,7 +495,7 @@ SOFTWARE.
       This pattern facet insures that only the above "OK" values are
       considered valid.
       -->
-      <pattern value="OK_.*"/>
+      <pattern value="OK_.{0,100}"/>
       <!--
       The remaining enums don't have OK_ prefixes, so will be
       considered well-formed, but won't pass validation, as
@@ -590,7 +590,7 @@ SOFTWARE.
       This pattern facet insures that only the above "OK" values are
       considered valid.
       -->
-      <pattern value="OK_.*"/>
+      <pattern value="OK_.{0,20}"/>
       <!--
       The remaining enums don't have OK_ prefixes, so will be
       considered well-formed, but won't pass validation, as
@@ -615,7 +615,7 @@ SOFTWARE.
       This pattern facet insures that only the above "OK" values are
       considered valid.
       -->
-      <pattern value="OK_.*"/>
+      <pattern value="OK_.{0,20}"/>
       <!--
       The remaining enums don't have OK_ prefixes, so will be
       considered well-formed, but won't pass validation, as
@@ -649,7 +649,7 @@ SOFTWARE.
       This pattern facet insures that only the above "OK" values are
       considered valid.
       -->
-      <pattern value="OK_.*"/>
+      <pattern value="OK_.{0,20}"/>
       <!--
       The remaining enums don't have OK_ prefixes, so will be
       considered well-formed, but won't pass validation, as
@@ -667,7 +667,7 @@ SOFTWARE.
       This pattern facet insures that only the above "OK" values are
       considered valid.
       -->
-      <pattern value="OK_.*"/>
+      <pattern value="OK_.{0,100}"/>
       <!--
       The remaining enums don't have OK_ prefixes, so will be
       considered well-formed, but won't pass validation, as

--- a/src/main/resources/com/owlcyberdefense/mil-std-2045/xsd/milstd2045_application_header.dfdl.xsd
+++ b/src/main/resources/com/owlcyberdefense/mil-std-2045/xsd/milstd2045_application_header.dfdl.xsd
@@ -109,6 +109,28 @@ SOFTWARE.
                        minOccurs="0" maxOccurs="16"
                        dfdl:occursCountKind="expression"
                        dfdl:occursCount="{ ../information_address_group_PI/value }"/>
+              <element name="invalid"
+                       minOccurs="0"
+                       dfdl:occursCountKind="expression"
+                       dfdl:occursCount='{
+               if ( fn:exists(../recipient_address_group[1]) and
+                    fn:exists(../information_address_group[1]) and
+                    fn:count(../recipient_address_group[1]/item) + fn:count(../information_address_group[1]/item) gt 16)
+               then 1 else 0
+               }'>
+                <complexType>
+                  <sequence>
+                    <element name="value" type="tns:invalidEnum"
+                             dfdl:inputValueCalc='{
+                             fn:concat("Too many address groups. Max of 16 for combination of recipient_address_group(",
+                                       fn:count(../../recipient_address_group[1]/item),
+                                       ") and information_address_group(",
+                                       fn:count(../../information_address_group[1]/item),
+                                       ")." )
+                                       }'/>
+                  </sequence>
+                </complexType>
+              </element>
               <sequence dfdl:hiddenGroupRef="msi:header_size_PI"/>
               <element name="header_size"
                        minOccurs="0"
@@ -127,7 +149,7 @@ SOFTWARE.
                 <complexType>
                   <sequence>
                     <element name="item"
-                             minOccurs="1" maxOccurs="unbounded"
+                             minOccurs="1" maxOccurs="16"
                              dfdl:occursCountKind="implicit">
                       <complexType>
                         <sequence>
@@ -297,7 +319,7 @@ SOFTWARE.
                                 <complexType>
                                   <sequence>
                                     <element name="item"
-                                             minOccurs="1" maxOccurs="unbounded"
+                                             minOccurs="1" maxOccurs="16"
                                              dfdl:occursCountKind="implicit">
                                       <complexType>
                                         <sequence>
@@ -427,7 +449,7 @@ SOFTWARE.
                             <complexType>
                               <sequence>
                                 <element name="item"
-                                         minOccurs="1" maxOccurs="unbounded"
+                                         minOccurs="1" maxOccurs="4"
                                          dfdl:occursCountKind="implicit">
                                   <complexType>
                                     <sequence>
@@ -570,7 +592,7 @@ SOFTWARE.
                     <complexType>
                       <sequence>
                         <element name="item"
-                                 minOccurs="1" maxOccurs="unbounded"
+                                 minOccurs="1" maxOccurs="17"
                                  dfdl:occursCountKind="implicit">
                           <complexType>
                             <sequence>

--- a/src/test/resources/com/owlcyberdefense/mil-std-2045/milstd2045.tdml
+++ b/src/test/resources/com/owlcyberdefense/mil-std-2045/milstd2045.tdml
@@ -87,7 +87,7 @@ SOFTWARE.
       <complexType>
         <sequence>
           <element name="item"
-                   minOccurs="1" maxOccurs="unbounded"
+                   minOccurs="1" maxOccurs="100"
                    dfdl:occursCountKind="implicit">
             <complexType>
               <sequence>
@@ -2039,5 +2039,186 @@ operator_reply_request_indicator set to 1">
       </documentPart>
     </document>
   </parserTestCase>
+
+  <parserTestCase name="test_2045_C_msghdr1_invalid_address_group_count" root="milstd2045_application_header"
+                  model="hdr">
+    <document bitOrder="LSBFirst">
+      <!-- From K02.1_1.1.VMB modified to have zero message size. -->
+      <documentPart type="byte" byteOrder="LTR"><![CDATA[
+      E29B6109673151308B8982594C14CC62A260161305B3982898C544C12C260A64315170161305B3982898C544C12C260A663151308B8982594C14C862A2A0130079254000000851A28CC2410F1000
+      ]]></documentPart>
+    </document>
+
+    <infoset>
+      <tdml:dfdlInfoset xmlns="">
+        <ex:milstd2045_application_header>
+          <contents>
+            <version>
+              <value>C</value>
+            </version>
+            <originator_address_group>
+              <urn>
+                <value>1229623</value>
+              </urn>
+            </originator_address_group>
+            <recipient_address_group>
+              <item>
+                <urn>
+                  <value>665132</value>
+                </urn>
+              </item>
+              <item>
+                <urn>
+                  <value>665132</value>
+                </urn>
+              </item>
+              <item>
+                <urn>
+                  <value>665132</value>
+                </urn>
+              </item>
+              <item>
+                <urn>
+                  <value>665132</value>
+                </urn>
+              </item>
+              <item>
+                <urn>
+                  <value>665132</value>
+                </urn>
+              </item>
+              <item>
+                <urn>
+                  <value>665132</value>
+                </urn>
+              </item>
+              <item>
+                <urn>
+                  <value>665132</value>
+                </urn>
+              </item>
+              <item>
+                <urn>
+                  <value>665132</value>
+                </urn>
+              </item>
+              <item>
+                <urn>
+                  <value>665132</value>
+                </urn>
+              </item>
+            </recipient_address_group>
+            <information_address_group>
+              <item>
+                <urn>
+                  <value>665132</value>
+                </urn>
+              </item>
+              <item>
+                <urn>
+                  <value>665132</value>
+                </urn>
+              </item>
+              <item>
+                <urn>
+                  <value>665132</value>
+                </urn>
+              </item>
+              <item>
+                <urn>
+                  <value>665132</value>
+                </urn>
+              </item>
+              <item>
+                <urn>
+                  <value>665132</value>
+                </urn>
+              </item>
+              <item>
+                <urn>
+                  <value>665132</value>
+                </urn>
+              </item>
+              <item>
+                <urn>
+                  <value>665132</value>
+                </urn>
+              </item>
+              <item>
+                <urn>
+                  <value>665132</value>
+                </urn>
+              </item>
+            </information_address_group>
+            <invalid>
+              <value><![CDATA[Too many address groups. Max of 16 for combination of recipient_address_group(9) and information_address_group(8).]]></value>
+            </invalid>
+            <header_size>
+              <value>78</value>
+            </header_size>
+            <message_handling_group>
+              <item>
+                <umf>
+                  <value>OK_VMF</value>
+                </umf>
+                <message_standard_version>
+                  <vmf_hdr_C>OK_6017A</vmf_hdr_C>
+                  <vmf>OK_6017A</vmf>
+                </message_standard_version>
+                <vmf_message_identification_group>
+                  <fad>
+                    <value>2</value>
+                  </fad>
+                  <message_number>
+                    <value>1</value>
+                  </message_number>
+                  <K_ID>K02.01</K_ID>
+                </vmf_message_identification_group>
+                <message_size>
+                  <value>0</value>
+                </message_size>
+                <operation_indicator>
+                  <value>Exercise</value>
+                </operation_indicator>
+                <retransmit_indicator>
+                  <value>Original_Message</value>
+                </retransmit_indicator>
+                <message_precedence_codes>
+                  <vmf_hdr_C>OK_Flash</vmf_hdr_C>
+                  <value>OK_Flash</value>
+                </message_precedence_codes>
+                <security_classification>
+                  <value>U</value>
+                </security_classification>
+                <originator_dtg_group>
+                  <dateTime>2018-10-12T20:48:01</dateTime>
+                  <dtg_extension>
+                    <value>30</value>
+                  </dtg_extension>
+                </originator_dtg_group>
+                <acknowledgement_request_group>
+                  <machine_acknowledge_request_indicator>
+                    <value>No_Acknowledgement_Required</value>
+                  </machine_acknowledge_request_indicator>
+                  <operator_acknowledge_request_indicator>
+                    <value>No_Acknowledgement_Required</value>
+                  </operator_acknowledge_request_indicator>
+                  <operator_reply_request_indicator>
+                    <value>No_Reply_Required</value>
+                  </operator_reply_request_indicator>
+                </acknowledgement_request_group>
+              </item>
+            </message_handling_group>
+          </contents>
+        </ex:milstd2045_application_header>
+      </tdml:dfdlInfoset>
+    </infoset>
+    <validationErrors>
+      <error>Too many address groups</error>
+      <error>recipient_address_group(9)</error>
+      <error>information_address_group(8)</error>
+    </validationErrors>
+  </parserTestCase>
+
 
 </testSuite>

--- a/src/test/scala/com/owlcyberdefense/mil_std_2045/Test2045Hdr.scala
+++ b/src/test/scala/com/owlcyberdefense/mil_std_2045/Test2045Hdr.scala
@@ -119,5 +119,7 @@ class Test2045Hdr {
   @Test def dtTest_06(): Unit = runner.runOneTest("dtTest_06")
   @Test def dtTest_07(): Unit = runner.runOneTest("dtTest_07")
 
-
+  @Test def test_2045_C_msghdr1_invalid_address_group_count() {
+    runner.runOneTest("test_2045_C_msghdr1_invalid_address_group_count")
+  }
 }


### PR DESCRIPTION
In anticipation of XSAT report that says to get rid of all unbounded maxOccurs and any ".*" in regex
I preempted that and fixed this schema in advance. 

Regular expression patterns "OK_.*" were replaced with OK_.{0,20} or OK_.{0,100} only. I did not try to make tighter bounds than that.

One validity check (optional invalid element)
added because the combination of
recipient_address_group and information_address_group items cannot exceed 16. So they each have maxOccurs='16' but also there is a specific check for the sum being greater than 16. A test was added to cover this.

Updated sbt version to latest.
Updated junit-interface and log4j-core to latest.

Issue #47