### PR TITLE
Version 1.2.0 - Removed use of tns namespace prefix

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "dfdl-mil-std-2045"
 
 organization := "com.owlcyberdefense"
 
-version := "1.1.0"
+version := "1.2.0"
 
 scalaVersion := "2.12.17"
 

--- a/src/main/resources/com/owlcyberdefense/mil-std-2045/xsd/milstd2045.common.dfdl.xsd
+++ b/src/main/resources/com/owlcyberdefense/mil-std-2045/xsd/milstd2045.common.dfdl.xsd
@@ -30,7 +30,7 @@ SOFTWARE.
 -->
 
 <schema targetNamespace="urn:milstd2045DFDL"
-        xmlns:tns="urn:milstd2045DFDL"
+        xmlns:ms2045="urn:milstd2045DFDL"
         xmlns:msi="urn:milstd2045DFDLInternal"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
@@ -54,7 +54,7 @@ SOFTWARE.
       <!-- the default format makes sequences behave properly, but every 
         element needs an explicit dfdl:ref to provide its length kind and (if optional 
         or repeating) occursCountKind. -->
-      <dfdl:format ref="tns:msCommon"/>
+      <dfdl:format ref="ms2045:msCommon"/>
 
     </appinfo>
   </annotation>
@@ -90,7 +90,7 @@ SOFTWARE.
         <complexType>
           <sequence>
             <sequence dfdl:hiddenGroupRef="msi:GRI_discriminator"/>
-            <group ref="tns:urn_unit_name_group"/>
+            <group ref="ms2045:urn_unit_name_group"/>
           </sequence>
         </complexType>
       </element>
@@ -106,7 +106,7 @@ SOFTWARE.
                dfdl:occursCount="{ ../urn_PI/value }">
         <complexType>
           <sequence>
-            <element name="value" type="tns:tIntField" dfdl:length="24"/>
+            <element name="value" type="ms2045:tIntField" dfdl:length="24"/>
           </sequence>
         </complexType>
       </element>
@@ -127,7 +127,7 @@ SOFTWARE.
                then 1 else 0}">
         <complexType>
           <sequence>
-            <element name="value" type="tns:invalidEnum"
+            <element name="value" type="ms2045:invalidEnum"
                      dfdl:inputValueCalc='{ "both URN and unit_name exist" }'/>
           </sequence>
         </complexType>
@@ -137,7 +137,7 @@ SOFTWARE.
 
   <group name="dtg_group">
     <sequence>
-      <group ref="tns:dateTime"/>
+      <group ref="ms2045:dateTime"/>
       <sequence dfdl:hiddenGroupRef="msi:dtg_extension_PI"/>
       <element name="dtg_extension"
                minOccurs="0"
@@ -145,7 +145,7 @@ SOFTWARE.
                dfdl:occursCount="{ ../dtg_extension_PI/value }">
         <complexType>
           <sequence>
-            <element name="value" type="tns:tIntField"
+            <element name="value" type="ms2045:tIntField"
                      dfdl:length="12"/>
           </sequence>
         </complexType>
@@ -158,7 +158,7 @@ SOFTWARE.
       <element name="authentication_data_length">
         <complexType>
           <sequence>
-            <element name="value" type="tns:tIntField" dfdl:length="7"
+            <element name="value" type="ms2045:tIntField" dfdl:length="7"
                      dfdl:outputValueCalc="{ (dfdl:valueLength(../../authentication_data/value, 'bytes') idiv 8) - 1 }"/>
           </sequence>
         </complexType>
@@ -166,7 +166,7 @@ SOFTWARE.
       <element name="authentication_data">
         <complexType>
           <sequence>
-            <element name="value" type="tns:tHexBinary"
+            <element name="value" type="ms2045:tHexBinary"
                      dfdl:length="{ (../../authentication_data_length/value + 1) * 8 }"
                      dfdl:lengthUnits="bytes"/>
           </sequence>

--- a/src/main/resources/com/owlcyberdefense/mil-std-2045/xsd/milstd2045.dateTime.dfdl.xsd
+++ b/src/main/resources/com/owlcyberdefense/mil-std-2045/xsd/milstd2045.dateTime.dfdl.xsd
@@ -30,7 +30,7 @@ SOFTWARE.
 -->
 
 <schema targetNamespace="urn:milstd2045DFDL"
-        xmlns:tns="urn:milstd2045DFDL"
+        xmlns:ms2045="urn:milstd2045DFDL"
         xmlns:msi="urn:milstd2045DFDLInternal"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
@@ -76,33 +76,33 @@ SOFTWARE.
 
   <group name="dateTime">
     <sequence>
-      <sequence dfdl:hiddenGroupRef="tns:ymdhms"/>
+      <sequence dfdl:hiddenGroupRef="ms2045:ymdhms"/>
       <sequence>
         <annotation>
           <appinfo source="http://www.ogf.org/dfdl/">
-            <dfdl:newVariableInstance ref="tns:yearStr">{
+            <dfdl:newVariableInstance ref="ms2045:yearStr">{
               if (year le 9) then fn:concat("200", xs:string(year))
               else if (year le 94) then fn:concat("20", xs:string(year))
               else if (year le 99) then fn:concat("19", xs:string(year))
               else fn:concat("2", xs:string(year))
               }
             </dfdl:newVariableInstance>
-            <dfdl:newVariableInstance ref="tns:monthStr">{
+            <dfdl:newVariableInstance ref="ms2045:monthStr">{
               if (month ge 10) then xs:string(month)
               else fn:concat("0", xs:string(month))
               }
             </dfdl:newVariableInstance>
-            <dfdl:newVariableInstance ref="tns:dayStr">{
+            <dfdl:newVariableInstance ref="ms2045:dayStr">{
               if (day ge 10) then xs:string(day)
               else fn:concat("0", xs:string(day))
               }
             </dfdl:newVariableInstance>
-            <dfdl:newVariableInstance ref="tns:hourStr">{
+            <dfdl:newVariableInstance ref="ms2045:hourStr">{
               if (hour ge 10) then xs:string(hour)
               else fn:concat("0", xs:string(hour))
               }
             </dfdl:newVariableInstance>
-            <dfdl:newVariableInstance ref="tns:minuteStr">{
+            <dfdl:newVariableInstance ref="ms2045:minuteStr">{
               if (minute ge 10) then xs:string(minute)
               else fn:concat("0", xs:string(minute))
               }
@@ -111,15 +111,15 @@ SOFTWARE.
             we map 63, which means no-statement, to 00 so that
             we can construct a valid DFDL xs:dateTime value
             -->
-            <dfdl:newVariableInstance ref="tns:secondStr">{
+            <dfdl:newVariableInstance ref="ms2045:secondStr">{
               if (second eq 63) then "00"
               else if (second ge 10) then xs:string(second)
               else fn:concat("0", xs:string(second))
               }
             </dfdl:newVariableInstance>
-            <dfdl:newVariableInstance ref="tns:wholeStr">{
-              fn:concat($tns:yearStr, "-", $tns:monthStr, "-", $tns:dayStr,
-              "T", $tns:hourStr, ":", $tns:minuteStr, ":", $tns:secondStr)
+            <dfdl:newVariableInstance ref="ms2045:wholeStr">{
+              fn:concat($ms2045:yearStr, "-", $ms2045:monthStr, "-", $ms2045:dayStr,
+              "T", $ms2045:hourStr, ":", $ms2045:minuteStr, ":", $ms2045:secondStr)
               }
             </dfdl:newVariableInstance>
           </appinfo>
@@ -140,12 +140,12 @@ SOFTWARE.
                 constructor.
                 -->
                 <dfdl:assert
-                  message='{ fn:concat("Malformed dateTime data: ", $tns:wholeStr) }'>{
-                  if (xs:dateTime($tns:wholeStr) ge $tns:minDateTime)
+                  message='{ fn:concat("Malformed dateTime data: ", $ms2045:wholeStr) }'>{
+                  if (xs:dateTime($ms2045:wholeStr) ge $ms2045:minDateTime)
                   then
                   fn:true()
                   else
-                  fn:error(fn:concat("The dateTime: ", $tns:wholeStr, " is less than minimum value ", $tns:minDateTime))
+                  fn:error(fn:concat("The dateTime: ", $ms2045:wholeStr, " is less than minimum value ", $ms2045:minDateTime))
                   }
                 </dfdl:assert>
               </appinfo>
@@ -182,9 +182,9 @@ SOFTWARE.
             </complexType>
           </element>
           <element
-            name="dateTime" type="tns:msDateTime"
+            name="dateTime" type="ms2045:msDateTime"
             dfdl:lengthKind="implicit"
-            dfdl:inputValueCalc='{ xs:dateTime($tns:wholeStr) }'/>
+            dfdl:inputValueCalc='{ xs:dateTime($ms2045:wholeStr) }'/>
         </sequence>
       </sequence>
     </sequence>
@@ -193,8 +193,8 @@ SOFTWARE.
   <simpleType name="msDateTime">
     <annotation>
       <appinfo source="http://www.ogf.org/dfdl/">
-        <dfdl:assert>{ . le $tns:maxDateTime and
-          . ge $tns:minDateTime }
+        <dfdl:assert>{ . le $ms2045:maxDateTime and
+          . ge $ms2045:minDateTime }
         </dfdl:assert>
       </appinfo>
     </annotation>
@@ -208,17 +208,17 @@ SOFTWARE.
 
   <group name="ymdhms">
     <sequence>
-      <element name="year" type="tns:year" dfdl:length="7"
+      <element name="year" type="ms2045:year" dfdl:length="7"
                dfdl:outputValueCalc='{ xs:unsignedInt(fn:year-from-dateTime(../dateTime) mod 100) }'/>
-      <element name="month" type="tns:month" dfdl:length="4"
+      <element name="month" type="ms2045:month" dfdl:length="4"
                dfdl:outputValueCalc='{ xs:unsignedInt(fn:month-from-dateTime(../dateTime)) }'/>
-      <element name="day" type="tns:day" dfdl:length="5"
+      <element name="day" type="ms2045:day" dfdl:length="5"
                dfdl:outputValueCalc='{ xs:unsignedInt(fn:day-from-dateTime(../dateTime)) }'/>
-      <element name="hour" type="tns:hour" dfdl:length="5"
+      <element name="hour" type="ms2045:hour" dfdl:length="5"
                dfdl:outputValueCalc='{ xs:unsignedInt(fn:hours-from-dateTime(../dateTime)) }'/>
-      <element name="minute" type="tns:minute" dfdl:length="6"
+      <element name="minute" type="ms2045:minute" dfdl:length="6"
                dfdl:outputValueCalc='{ xs:unsignedInt(fn:minutes-from-dateTime(../dateTime)) }'/>
-      <element name="second" type="tns:second"
+      <element name="second" type="ms2045:second"
                dfdl:outputValueCalc='{
                if (fn:exists(../timeStatus[1]/seconds))
                then 63
@@ -230,34 +230,34 @@ SOFTWARE.
 
 
   <simpleType name="year">
-    <restriction base="tns:checkedInt">
+    <restriction base="ms2045:checkedInt">
       <maxInclusive value="99"/>
     </restriction>
   </simpleType>
 
   <simpleType name="month">
-    <restriction base="tns:checkedInt">
+    <restriction base="ms2045:checkedInt">
       <minInclusive value="1"/>
       <maxInclusive value="12"/>
     </restriction>
   </simpleType>
 
   <simpleType name="day">
-    <restriction base="tns:checkedInt">
+    <restriction base="ms2045:checkedInt">
       <minInclusive value="1"/>
       <maxInclusive value="31"/>
     </restriction>
   </simpleType>
 
   <simpleType name="hour">
-    <restriction base="tns:checkedInt">
+    <restriction base="ms2045:checkedInt">
       <minInclusive value="0"/>
       <maxInclusive value="23"/>
     </restriction>
   </simpleType>
 
   <simpleType name="minute">
-    <restriction base="tns:checkedInt">
+    <restriction base="ms2045:checkedInt">
       <minInclusive value="0"/>
       <maxInclusive value="59"/>
     </restriction>
@@ -268,12 +268,12 @@ SOFTWARE.
   <simpleType name="second" dfdl:lengthKind="explicit" dfdl:length="6">
     <union>
       <simpleType>
-        <restriction base="tns:checkedInt">
+        <restriction base="ms2045:checkedInt">
           <maxInclusive value="59"/>
         </restriction>
       </simpleType>
       <simpleType>
-        <restriction base="tns:checkedInt">
+        <restriction base="ms2045:checkedInt">
           <enumeration value="63"/>
         </restriction>
       </simpleType>

--- a/src/main/resources/com/owlcyberdefense/mil-std-2045/xsd/milstd2045.enums.dfdl.xsd
+++ b/src/main/resources/com/owlcyberdefense/mil-std-2045/xsd/milstd2045.enums.dfdl.xsd
@@ -30,7 +30,7 @@ SOFTWARE.
 -->
 
 <schema targetNamespace="urn:milstd2045DFDL"
-        xmlns:tns="urn:milstd2045DFDL"
+        xmlns:ms2045="urn:milstd2045DFDL"
         xmlns:msi="urn:milstd2045DFDLInternal"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
@@ -61,35 +61,35 @@ SOFTWARE.
   </simpleType>
 
   <simpleType name="enumBase">
-    <restriction base="tns:checkedInt"/>
+    <restriction base="ms2045:checkedInt"/>
   </simpleType>
 
   <simpleType name="enum1" dfdl:length="1">
-    <xs:restriction base="tns:enumBase"/>
+    <xs:restriction base="ms2045:enumBase"/>
   </simpleType>
 
   <simpleType name="enum2" dfdl:length="2">
-    <xs:restriction base="tns:enumBase"/>
+    <xs:restriction base="ms2045:enumBase"/>
   </simpleType>
 
   <simpleType name="enum3" dfdl:length="3">
-    <xs:restriction base="tns:enumBase"/>
+    <xs:restriction base="ms2045:enumBase"/>
   </simpleType>
 
   <simpleType name="enum4" dfdl:length="4">
-    <xs:restriction base="tns:enumBase"/>
+    <xs:restriction base="ms2045:enumBase"/>
   </simpleType>
 
   <simpleType name="enum5" dfdl:length="5">
-    <xs:restriction base="tns:enumBase"/>
+    <xs:restriction base="ms2045:enumBase"/>
   </simpleType>
 
   <simpleType name="enum6" dfdl:length="6">
-    <xs:restriction base="tns:enumBase"/>
+    <xs:restriction base="ms2045:enumBase"/>
   </simpleType>
 
   <simpleType name="enum9" dfdl:length="9">
-    <xs:restriction base="tns:enumBase"/>
+    <xs:restriction base="ms2045:enumBase"/>
   </simpleType>
 
   <!--
@@ -116,8 +116,8 @@ SOFTWARE.
     </restriction>
   </simpleType>
 
-  <simpleType name="versionEnum" dfdlx:repType="tns:enum4">
-    <restriction base="tns:enumString">
+  <simpleType name="versionEnum" dfdlx:repType="ms2045:enum4">
+    <restriction base="ms2045:enumString">
       <enumeration value="base" dfdlx:repValues="0"/>
       <enumeration value="B" dfdlx:repValues="1"/>
       <enumeration value="C" dfdlx:repValues="2"/>
@@ -138,16 +138,16 @@ SOFTWARE.
     </restriction>
   </simpleType>
 
-  <simpleType name="dataCompressionEnum" dfdlx:repType="tns:enum2">
-    <restriction base="tns:enumString">
+  <simpleType name="dataCompressionEnum" dfdlx:repType="ms2045:enum2">
+    <restriction base="ms2045:enumString">
       <enumeration value="LZW" dfdlx:repValues="0"/>
       <enumeration value="GZIP" dfdlx:repValues="1"/>
       <pattern value="OK_.{0,20}"/><!-- none of these are implemented yet -->
     </restriction>
   </simpleType>
 
-  <simpleType name="umfEnum" dfdlx:repType="tns:enum4">
-    <restriction base="tns:enumString">
+  <simpleType name="umfEnum" dfdlx:repType="ms2045:enum4">
+    <restriction base="ms2045:enumString">
       <enumeration value="OK_Link_16" dfdlx:repValues="0"/>
       <enumeration value="OK_Binary_File" dfdlx:repValues="1"/>
       <enumeration value="OK_VMF" dfdlx:repValues="2"/>
@@ -178,8 +178,8 @@ SOFTWARE.
     </restriction>
   </simpleType>
 
-  <simpleType name="messsageStandardVersionLink16Enum" dfdlx:repType="tns:enum4">
-    <restriction base="tns:enumString">
+  <simpleType name="messsageStandardVersionLink16Enum" dfdlx:repType="ms2045:enum4">
+    <restriction base="ms2045:enumString">
       <enumeration value="OK_6016" dfdlx:repValues="0"/>
       <enumeration value="OK_6016A" dfdlx:repValues="1"/>
       <enumeration value="OK_6016B" dfdlx:repValues="2"/>
@@ -200,7 +200,7 @@ SOFTWARE.
   </simpleType>
 
   <group name="h_messageStandardVersionVMFGroup">
-    <choice dfdl:choiceDispatchKey="{ $tns:versionSpec }">
+    <choice dfdl:choiceDispatchKey="{ $ms2045:versionSpec }">
       <!--
       DFDL has no way to discriminate a choice at unparse time
       based on data values in the infoset. So choices really cannot
@@ -209,15 +209,15 @@ SOFTWARE.
       Hence, this group cannot be hidden.
       -->
       <element name="vmf_hdr_C" dfdl:choiceBranchKey="C"
-               type="tns:messsageStandardVersionVMFEnum_C"/>
+               type="ms2045:messsageStandardVersionVMFEnum_C"/>
       <element name="vmf_hdr_D1" dfdl:choiceBranchKey="D1"
-               type="tns:messsageStandardVersionVMFEnum_D1"/>
+               type="ms2045:messsageStandardVersionVMFEnum_D1"/>
     </choice>
   </group>
 
   <group name="messageStandardVersionVMFGroup">
     <sequence>
-      <group ref="tns:h_messageStandardVersionVMFGroup"/>
+      <group ref="ms2045:h_messageStandardVersionVMFGroup"/>
       <element name="vmf" type="xs:string"
                dfdl:inputValueCalc="{
               if (fn:exists(../vmf_hdr_C)) then ../vmf_hdr_C else ../vmf_hdr_D1
@@ -225,8 +225,8 @@ SOFTWARE.
     </sequence>
   </group>
 
-  <simpleType name="messsageStandardVersionVMFEnum_C" dfdlx:repType="tns:enum4">
-    <restriction base="tns:enumString">
+  <simpleType name="messsageStandardVersionVMFEnum_C" dfdlx:repType="ms2045:enum4">
+    <restriction base="ms2045:enumString">
       <enumeration value="OK_TIDP-TE_R2" dfdlx:repValues="0"/>
       <enumeration value="OK_TIDP-TE_R3" dfdlx:repValues="1"/>
       <enumeration value="OK_TIDP-TE_R4" dfdlx:repValues="2"/>
@@ -253,8 +253,8 @@ SOFTWARE.
     </restriction>
   </simpleType>
 
-  <simpleType name="messsageStandardVersionVMFEnum_D1" dfdlx:repType="tns:enum4">
-    <restriction base="tns:enumString">
+  <simpleType name="messsageStandardVersionVMFEnum_D1" dfdlx:repType="ms2045:enum4">
+    <restriction base="ms2045:enumString">
       <enumeration value="OK_TIDP-TE_R2" dfdlx:repValues="0"/>
       <enumeration value="OK_TIDP-TE_R3" dfdlx:repValues="1"/>
       <enumeration value="OK_TIDP-TE_R4" dfdlx:repValues="2"/>
@@ -282,8 +282,8 @@ SOFTWARE.
   </simpleType>
 
 
-  <simpleType name="messsageStandardVersionNITFSEnum" dfdlx:repType="tns:enum4">
-    <restriction base="tns:enumString">
+  <simpleType name="messsageStandardVersionNITFSEnum" dfdlx:repType="ms2045:enum4">
+    <restriction base="ms2045:enumString">
       <enumeration value="OK_2500B_Notice_2" dfdlx:repValues="0"/><!-- Undefined in rev C -->
       <!--
       This pattern facet insures that only the above "OK" values are
@@ -314,8 +314,8 @@ SOFTWARE.
     </restriction>
   </simpleType>
 
-  <simpleType name="messsageStandardVersionUSMTFEnum" dfdlx:repType="tns:enum4">
-    <restriction base="tns:enumString">
+  <simpleType name="messsageStandardVersionUSMTFEnum" dfdlx:repType="ms2045:enum4">
+    <restriction base="ms2045:enumString">
       <enumeration value="OK_1993" dfdlx:repValues="0"/>
       <enumeration value="OK_1995" dfdlx:repValues="1"/>
       <enumeration value="OK_1997" dfdlx:repValues="2"/>
@@ -335,8 +335,8 @@ SOFTWARE.
     </restriction>
   </simpleType>
 
-  <simpleType name="messsageStandardVersionXML_MTFEnum" dfdlx:repType="tns:enum4">
-    <restriction base="tns:enumString">
+  <simpleType name="messsageStandardVersionXML_MTFEnum" dfdlx:repType="ms2045:enum4">
+    <restriction base="ms2045:enumString">
       <enumeration value="Undefined_00" dfdlx:repValues="0"/>
       <enumeration value="Undefined_01" dfdlx:repValues="1"/>
       <enumeration value="Undefined_02" dfdlx:repValues="2"/>
@@ -368,7 +368,7 @@ SOFTWARE.
   </simpleType>
 
   <group name="h_messageStandardVersionXMLVMFGroup">
-    <choice dfdl:choiceDispatchKey="{ $tns:versionSpec }">
+    <choice dfdl:choiceDispatchKey="{ $ms2045:versionSpec }">
       <!--
       DFDL has no way to discriminate a choice at unparse time
       based on data values in the infoset. So choices really cannot
@@ -377,15 +377,15 @@ SOFTWARE.
       Hence, this group cannot be hidden.
       -->
       <element name="vmf_hdr_C_xml" dfdl:choiceBranchKey="C"
-               type="tns:messsageStandardVersionXMLVMFEnum_C"/>
+               type="ms2045:messsageStandardVersionXMLVMFEnum_C"/>
       <element name="vmf_hdr_D1_xml" dfdl:choiceBranchKey="D1"
-               type="tns:messsageStandardVersionXMLVMFEnum_D1"/>
+               type="ms2045:messsageStandardVersionXMLVMFEnum_D1"/>
     </choice>
   </group>
 
   <group name="messageStandardVersionXMLVMFGroup">
     <sequence>
-      <group ref="tns:h_messageStandardVersionXMLVMFGroup"/>
+      <group ref="ms2045:h_messageStandardVersionXMLVMFGroup"/>
       <element name="xml_vmf" type="xs:string"
                dfdl:inputValueCalc="{
               if (fn:exists(../vmf_hdr_C)) then ../vmf_hdr_C else ../vmf_hdr_D1
@@ -397,8 +397,8 @@ SOFTWARE.
   These are almost the same as the non-XML VMF enums.
   They differen in that the first 3 enums are undefined here.
   -->
-  <simpleType name="messsageStandardVersionXMLVMFEnum_C" dfdlx:repType="tns:enum4">
-    <restriction base="tns:enumString">
+  <simpleType name="messsageStandardVersionXMLVMFEnum_C" dfdlx:repType="ms2045:enum4">
+    <restriction base="ms2045:enumString">
       <enumeration value="Undefined_00" dfdlx:repValues="0"/>
       <enumeration value="Undefined_01" dfdlx:repValues="1"/>
       <enumeration value="Undefined_02" dfdlx:repValues="2"/>
@@ -423,8 +423,8 @@ SOFTWARE.
     </restriction>
   </simpleType>
 
-  <simpleType name="messsageStandardVersionXMLVMFEnum_D1" dfdlx:repType="tns:enum4">
-    <restriction base="tns:enumString">
+  <simpleType name="messsageStandardVersionXMLVMFEnum_D1" dfdlx:repType="ms2045:enum4">
+    <restriction base="ms2045:enumString">
       <enumeration value="Undefined_00" dfdlx:repValues="0"/>
       <enumeration value="Undefined_01" dfdlx:repValues="1"/>
       <enumeration value="Undefined_02" dfdlx:repValues="2"/>
@@ -450,8 +450,8 @@ SOFTWARE.
   </simpleType>
 
 
-  <simpleType name="cantcoReasonCodewordsEnum" dfdlx:repType="tns:enum3">
-    <restriction base="tns:enumString">
+  <simpleType name="cantcoReasonCodewordsEnum" dfdlx:repType="ms2045:enum3">
+    <restriction base="ms2045:enumString">
       <enumeration value="OK_Communications" dfdlx:repValues="0"/>
       <enumeration value="OK_Ammunition" dfdlx:repValues="1"/>
       <enumeration value="OK_Personnel" dfdlx:repValues="2"/>
@@ -463,8 +463,8 @@ SOFTWARE.
     </restriction>
   </simpleType>
 
-  <simpleType name="cantproReasonCodewordsEnum" dfdlx:repType="tns:enum6">
-    <restriction base="tns:enumString">
+  <simpleType name="cantproReasonCodewordsEnum" dfdlx:repType="ms2045:enum6">
+    <restriction base="ms2045:enumString">
       <enumeration value="Undefined_00" dfdlx:repValues="0"/>
       <enumeration value="OK_Field_content_invalid_01" dfdlx:repValues="1"/>
       <enumeration value="OK_Message_incorrectly_routed_02" dfdlx:repValues="2"/>
@@ -543,8 +543,8 @@ SOFTWARE.
     </restriction>
   </simpleType>
 
-  <simpleType name="operationIndicatorEnum" dfdlx:repType="tns:enum2">
-    <restriction base="tns:enumString">
+  <simpleType name="operationIndicatorEnum" dfdlx:repType="ms2045:enum2">
+    <restriction base="ms2045:enumString">
       <enumeration value="Operation" dfdlx:repValues="0"/>
       <enumeration value="Exercise" dfdlx:repValues="1"/>
       <enumeration value="Simulation" dfdlx:repValues="2"/>
@@ -552,15 +552,15 @@ SOFTWARE.
     </restriction>
   </simpleType>
 
-  <simpleType name="retransmitIndicatorEnum" dfdlx:repType="tns:enum1">
-    <restriction base="tns:enumString">
+  <simpleType name="retransmitIndicatorEnum" dfdlx:repType="ms2045:enum1">
+    <restriction base="ms2045:enumString">
       <enumeration value="Original_Message" dfdlx:repValues="0"/>
       <enumeration value="Retransmitted_Message" dfdlx:repValues="1"/>
     </restriction>
   </simpleType>
 
   <group name="h_messagePrecedenceCodesGroup">
-    <choice dfdl:choiceDispatchKey="{ $tns:versionSpec }">
+    <choice dfdl:choiceDispatchKey="{ $ms2045:versionSpec }">
       <!--
       DFDL has no way to discriminate a choice at unparse time
       based on data values in the infoset. So choices really cannot
@@ -569,15 +569,15 @@ SOFTWARE.
       Hence, this group cannot be hidden.
       -->
       <element name="vmf_hdr_C" dfdl:choiceBranchKey="C"
-               type="tns:messagePrecedenceCodesEnum_C"/>
+               type="ms2045:messagePrecedenceCodesEnum_C"/>
       <element name="vmf_hdr_D1" dfdl:choiceBranchKey="D1"
-               type="tns:messagePrecedenceCodesEnum_D"/>
+               type="ms2045:messagePrecedenceCodesEnum_D"/>
     </choice>
   </group>
 
   <group name="messagePrecedenceCodesGroup">
     <sequence>
-      <group ref="tns:h_messagePrecedenceCodesGroup"/>
+      <group ref="ms2045:h_messagePrecedenceCodesGroup"/>
       <element name="value" type="xs:string"
                dfdl:inputValueCalc="{
               if (fn:exists(../vmf_hdr_C)) then ../vmf_hdr_C else ../vmf_hdr_D1
@@ -585,8 +585,8 @@ SOFTWARE.
     </sequence>
   </group>
 
-  <simpleType name="messagePrecedenceCodesEnum_C" dfdlx:repType="tns:enum3">
-    <restriction base="tns:enumString">
+  <simpleType name="messagePrecedenceCodesEnum_C" dfdlx:repType="ms2045:enum3">
+    <restriction base="ms2045:enumString">
       <enumeration value="OK_Emergency" dfdlx:repValues="2"/>
       <enumeration value="OK_Flash" dfdlx:repValues="4"/>
       <enumeration value="OK_Immediate" dfdlx:repValues="5"/>
@@ -610,8 +610,8 @@ SOFTWARE.
     </restriction>
   </simpleType>
 
-  <simpleType name="messagePrecedenceCodesEnum_D" dfdlx:repType="tns:enum3">
-    <restriction base="tns:enumString">
+  <simpleType name="messagePrecedenceCodesEnum_D" dfdlx:repType="ms2045:enum3">
+    <restriction base="ms2045:enumString">
       <enumeration value="OK_Routine" dfdlx:repValues="0"/>
       <enumeration value="OK_Priority" dfdlx:repValues="1"/>
       <enumeration value="OK_Immediate" dfdlx:repValues="2"/>
@@ -634,8 +634,8 @@ SOFTWARE.
     </restriction>
   </simpleType>
 
-  <simpleType name="securityClassificationEnum" dfdlx:repType="tns:enum2">
-    <restriction base="tns:enumString">
+  <simpleType name="securityClassificationEnum" dfdlx:repType="ms2045:enum2">
+    <restriction base="ms2045:enumString">
       <enumeration value="U" dfdlx:repValues="0"/>
       <enumeration value="C" dfdlx:repValues="1"/>
       <enumeration value="S" dfdlx:repValues="2"/>
@@ -643,8 +643,8 @@ SOFTWARE.
     </restriction>
   </simpleType>
 
-  <simpleType name="receiptComplianceEnum" dfdlx:repType="tns:enum3">
-    <restriction base="tns:enumString">
+  <simpleType name="receiptComplianceEnum" dfdlx:repType="ms2045:enum3">
+    <restriction base="ms2045:enumString">
       <enumeration value="Undefined_0" dfdlx:repValues="0"/>
       <enumeration value="OK_MR" dfdlx:repValues="1"/>
       <enumeration value="OK_CANTPRO" dfdlx:repValues="2"/>
@@ -667,8 +667,8 @@ SOFTWARE.
     </restriction>
   </simpleType>
 
-  <simpleType name="securityParameterInformationEnum" dfdlx:repType="tns:enum4">
-    <restriction base="tns:enumString">
+  <simpleType name="securityParameterInformationEnum" dfdlx:repType="ms2045:enum4">
+    <restriction base="ms2045:enumString">
       <enumeration value="OK_Authentication_No_Encryption" dfdlx:repValues="0"/>
       <!--
       This pattern facet insures that only the above "OK" values are
@@ -699,15 +699,15 @@ SOFTWARE.
     </restriction>
   </simpleType>
 
-  <simpleType name="signedAcknowledgeRequestIndicatorEnum" dfdlx:repType="tns:enum1">
-    <restriction base="tns:enumString">
+  <simpleType name="signedAcknowledgeRequestIndicatorEnum" dfdlx:repType="ms2045:enum1">
+    <restriction base="ms2045:enumString">
       <enumeration value="No_Signed_Response_Required" dfdlx:repValues="0"/>
       <enumeration value="Signed_Response_Requested" dfdlx:repValues="1"/>
     </restriction>
   </simpleType>
 
-  <xs:simpleType name="dfi4127_dui005_nationality_Enum" dfdlx:repType="tns:enum9">
-    <xs:restriction base="tns:enumString">
+  <xs:simpleType name="dfi4127_dui005_nationality_Enum" dfdlx:repType="ms2045:enum9">
+    <xs:restriction base="ms2045:enumString">
       <xs:enumeration value="NO_STATEMENT" dfdlx:repValues="0"/>
       <xs:enumeration value="AFGHANISTAN_(AF)" dfdlx:repValues="1"/>
       <xs:enumeration value="ALBANIA_(AL)" dfdlx:repValues="2"/>
@@ -1225,15 +1225,15 @@ SOFTWARE.
 
 
 
-  <simpleType name="acknowledgeRequestIndicatorEnum" dfdlx:repType="tns:enum1">
-    <restriction base="tns:enumString">
+  <simpleType name="acknowledgeRequestIndicatorEnum" dfdlx:repType="ms2045:enum1">
+    <restriction base="ms2045:enumString">
       <enumeration value="No_Acknowledgement_Required" dfdlx:repValues="0"/>
       <enumeration value="Acknowledgement_Requested" dfdlx:repValues="1"/>
     </restriction>
   </simpleType>
 
-  <simpleType name="replyRequestIndicatorEnum" dfdlx:repType="tns:enum1">
-    <restriction base="tns:enumString">
+  <simpleType name="replyRequestIndicatorEnum" dfdlx:repType="ms2045:enum1">
+    <restriction base="ms2045:enumString">
       <enumeration value="No_Reply_Required" dfdlx:repValues="0"/>
       <enumeration value="Reply_Requested" dfdlx:repValues="1"/>
     </restriction>

--- a/src/main/resources/com/owlcyberdefense/mil-std-2045/xsd/milstd2045.internal.dfdl.xsd
+++ b/src/main/resources/com/owlcyberdefense/mil-std-2045/xsd/milstd2045.internal.dfdl.xsd
@@ -31,7 +31,7 @@ SOFTWARE.
   ]]> -->
 <schema
   targetNamespace="urn:milstd2045DFDLInternal"
-  xmlns:tns="urn:milstd2045DFDLInternal"
+  xmlns:ms2045="urn:milstd2045DFDLInternal"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
   xmlns:dfdlx="http://www.ogf.org/dfdl/dfdl-1.0/extensions"
@@ -57,7 +57,7 @@ SOFTWARE.
       occursCountKind.
       -->
 
-      <dfdl:format ref="tns:msBase"/>
+      <dfdl:format ref="ms2045:msBase"/>
     </appinfo>
   </annotation>
 

--- a/src/main/resources/com/owlcyberdefense/mil-std-2045/xsd/milstd2045.internal_PI.dfdl.xsd
+++ b/src/main/resources/com/owlcyberdefense/mil-std-2045/xsd/milstd2045.internal_PI.dfdl.xsd
@@ -31,7 +31,7 @@ SOFTWARE.
   ]]> -->
 <schema
   targetNamespace="urn:milstd2045DFDLInternal"
-  xmlns:tns="urn:milstd2045DFDLInternal"
+  xmlns:ms2045="urn:milstd2045DFDLInternal"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
   xmlns:dfdlx="http://www.ogf.org/dfdl/dfdl-1.0/extensions"
@@ -58,7 +58,7 @@ SOFTWARE.
 
       <dfdl:defineFormat name="msBase">
         <dfdl:format
-          ref="tns:GeneralFormat"
+          ref="ms2045:GeneralFormat"
           fillByte="%#r00;"
           lengthUnits="bits"
           alignment="1"
@@ -84,7 +84,7 @@ SOFTWARE.
       occursCountKind.
       -->
 
-      <dfdl:format ref="tns:msBase"/>
+      <dfdl:format ref="ms2045:msBase"/>
     </appinfo>
   </annotation>
 
@@ -92,11 +92,11 @@ SOFTWARE.
     are three reusable groups named FPI, FRI, GPI, and GRI. -->
 
   <simpleType name="presenceIndicator" dfdl:length="1"
-              dfdl:ref="tns:msBase" dfdl:lengthKind="explicit">
+              dfdl:ref="ms2045:msBase" dfdl:lengthKind="explicit">
     <restriction base="xs:unsignedInt"/>
   </simpleType>
 
-  <simpleType name="repeatIndicator" dfdl:length="1" dfdl:ref="tns:msBase"
+  <simpleType name="repeatIndicator" dfdl:length="1" dfdl:ref="ms2045:msBase"
               dfdl:lengthKind="explicit">
     <restriction base="xs:unsignedInt"/>
   </simpleType>
@@ -114,7 +114,7 @@ SOFTWARE.
           </appinfo>
         </annotation>
       </sequence>
-      <element name="GRI" type="tns:repeatIndicator"
+      <element name="GRI" type="ms2045:repeatIndicator"
                dfdl:outputValueCalc="{ if (dfdl:occursIndex() lt fn:count(..)) then 1 else 0 }"/>
     </sequence>
   </group>
@@ -133,7 +133,7 @@ SOFTWARE.
           </appinfo>
         </annotation>
       </sequence>
-      <element name="FRI" type="tns:repeatIndicator"
+      <element name="FRI" type="ms2045:repeatIndicator"
                dfdl:outputValueCalc="{ if (dfdl:occursIndex() lt fn:count(..)) then 1 else 0 }"/>
     </sequence>
   </group>
@@ -143,7 +143,7 @@ SOFTWARE.
       <element name="data_compression_type_PI" dfdl:lengthKind="implicit">
         <complexType>
           <sequence>
-            <element name="value" type="tns:presenceIndicator"
+            <element name="value" type="ms2045:presenceIndicator"
                      dfdl:outputValueCalc='{ fn:count(../../data_compression_type) }'/>
           </sequence>
         </complexType>
@@ -156,7 +156,7 @@ SOFTWARE.
       <element name="originator_address_group_PI" dfdl:lengthKind="implicit">
         <complexType>
           <sequence>
-            <element name="value" type="tns:presenceIndicator"
+            <element name="value" type="ms2045:presenceIndicator"
                      dfdl:outputValueCalc='{ fn:count(../../originator_address_group) }'/>
           </sequence>
         </complexType>
@@ -169,7 +169,7 @@ SOFTWARE.
       <element name="recipient_address_group_PI" dfdl:lengthKind="implicit">
         <complexType>
           <sequence>
-            <element name="value" type="tns:presenceIndicator"
+            <element name="value" type="ms2045:presenceIndicator"
                      dfdl:outputValueCalc='{ fn:count(../../recipient_address_group) }'/>
           </sequence>
         </complexType>
@@ -182,7 +182,7 @@ SOFTWARE.
       <element name="information_address_group_PI" dfdl:lengthKind="implicit">
         <complexType>
           <sequence>
-            <element name="value" type="tns:presenceIndicator"
+            <element name="value" type="ms2045:presenceIndicator"
                      dfdl:outputValueCalc='{ fn:count(../../information_address_group) }'/>
           </sequence>
         </complexType>
@@ -195,7 +195,7 @@ SOFTWARE.
       <element name="urn_PI" dfdl:lengthKind="implicit">
         <complexType>
           <sequence>
-            <element name="value" type="tns:presenceIndicator"
+            <element name="value" type="ms2045:presenceIndicator"
                      dfdl:outputValueCalc='{ fn:count(../../urn) }'/>
           </sequence>
         </complexType>
@@ -208,7 +208,7 @@ SOFTWARE.
       <element name="unit_name_PI" dfdl:lengthKind="implicit">
         <complexType>
           <sequence>
-            <element name="value" type="tns:presenceIndicator"
+            <element name="value" type="ms2045:presenceIndicator"
                      dfdl:outputValueCalc='{ fn:count(../../unit_name) }'/>
           </sequence>
         </complexType>
@@ -221,7 +221,7 @@ SOFTWARE.
       <element name="header_size_PI" dfdl:lengthKind="implicit">
         <complexType>
           <sequence>
-            <element name="value" type="tns:presenceIndicator"
+            <element name="value" type="ms2045:presenceIndicator"
                      dfdl:outputValueCalc='{ fn:count(../../header_size) }'/>
           </sequence>
         </complexType>
@@ -234,7 +234,7 @@ SOFTWARE.
       <element name="message_standard_version_PI" dfdl:lengthKind="implicit">
         <complexType>
           <sequence>
-            <element name="value" type="tns:presenceIndicator"
+            <element name="value" type="ms2045:presenceIndicator"
                      dfdl:outputValueCalc='{ fn:count(../../message_standard_version) }'/>
           </sequence>
         </complexType>
@@ -247,7 +247,7 @@ SOFTWARE.
       <element name="vmf_message_identification_group_PI" dfdl:lengthKind="implicit">
         <complexType>
           <sequence>
-            <element name="value" type="tns:presenceIndicator"
+            <element name="value" type="ms2045:presenceIndicator"
                      dfdl:outputValueCalc='{ fn:count(../../vmf_message_identification_group) }'/>
           </sequence>
         </complexType>
@@ -260,7 +260,7 @@ SOFTWARE.
       <element name="file_name_PI" dfdl:lengthKind="implicit">
         <complexType>
           <sequence>
-            <element name="value" type="tns:presenceIndicator"
+            <element name="value" type="ms2045:presenceIndicator"
                      dfdl:outputValueCalc='{ fn:count(../../file_name) }'/>
           </sequence>
         </complexType>
@@ -273,7 +273,7 @@ SOFTWARE.
       <element name="message_size_PI" dfdl:lengthKind="implicit">
         <complexType>
           <sequence>
-            <element name="value" type="tns:presenceIndicator"
+            <element name="value" type="ms2045:presenceIndicator"
                      dfdl:outputValueCalc='{ fn:count(../../message_size) }'/>
           </sequence>
         </complexType>
@@ -286,7 +286,7 @@ SOFTWARE.
       <element name="originator_dtg_group_PI" dfdl:lengthKind="implicit">
         <complexType>
           <sequence>
-            <element name="value" type="tns:presenceIndicator"
+            <element name="value" type="ms2045:presenceIndicator"
                      dfdl:outputValueCalc='{ fn:count(../../originator_dtg_group) }'/>
           </sequence>
         </complexType>
@@ -299,7 +299,7 @@ SOFTWARE.
       <element name="dtg_extension_PI" dfdl:lengthKind="implicit">
         <complexType>
           <sequence>
-            <element name="value" type="tns:presenceIndicator"
+            <element name="value" type="ms2045:presenceIndicator"
                      dfdl:outputValueCalc='{ fn:count(../../dtg_extension) }'/>
           </sequence>
         </complexType>
@@ -312,7 +312,7 @@ SOFTWARE.
       <element name="perishability_dtg_group_PI" dfdl:lengthKind="implicit">
         <complexType>
           <sequence>
-            <element name="value" type="tns:presenceIndicator"
+            <element name="value" type="ms2045:presenceIndicator"
                      dfdl:outputValueCalc='{ fn:count(../../perishability_dtg_group) }'/>
           </sequence>
         </complexType>
@@ -325,7 +325,7 @@ SOFTWARE.
       <element name="acknowledgement_request_group_PI" dfdl:lengthKind="implicit">
         <complexType>
           <sequence>
-            <element name="value" type="tns:presenceIndicator"
+            <element name="value" type="ms2045:presenceIndicator"
                      dfdl:outputValueCalc='{ fn:count(../../acknowledgement_request_group) }'/>
           </sequence>
         </complexType>
@@ -338,7 +338,7 @@ SOFTWARE.
       <element name="response_data_group_PI" dfdl:lengthKind="implicit">
         <complexType>
           <sequence>
-            <element name="value" type="tns:presenceIndicator"
+            <element name="value" type="ms2045:presenceIndicator"
                      dfdl:outputValueCalc='{ fn:count(../../response_data_group) }'/>
           </sequence>
         </complexType>
@@ -351,7 +351,7 @@ SOFTWARE.
       <element name="reference_message_data_group_PI" dfdl:lengthKind="implicit">
         <complexType>
           <sequence>
-            <element name="value" type="tns:presenceIndicator"
+            <element name="value" type="ms2045:presenceIndicator"
                      dfdl:outputValueCalc='{ fn:count(../../reference_message_data_group) }'/>
           </sequence>
         </complexType>
@@ -365,7 +365,7 @@ SOFTWARE.
       <element name="message_security_group_PI" dfdl:lengthKind="implicit">
         <complexType>
           <sequence>
-            <element name="value" type="tns:presenceIndicator"
+            <element name="value" type="ms2045:presenceIndicator"
                      dfdl:outputValueCalc='{ fn:count(../../message_security_group) }'/>
           </sequence>
         </complexType>
@@ -378,7 +378,7 @@ SOFTWARE.
       <element name="keying_material_group_PI" dfdl:lengthKind="implicit">
         <complexType>
           <sequence>
-            <element name="value" type="tns:presenceIndicator"
+            <element name="value" type="ms2045:presenceIndicator"
                      dfdl:outputValueCalc='{ fn:count(../../keying_material_group) }'/>
           </sequence>
         </complexType>
@@ -392,7 +392,7 @@ SOFTWARE.
       <element name="cryptographic_initialization_group_PI" dfdl:lengthKind="implicit">
         <complexType>
           <sequence>
-            <element name="value" type="tns:presenceIndicator"
+            <element name="value" type="ms2045:presenceIndicator"
                      dfdl:outputValueCalc='{ fn:count(../../cryptographic_initialization_group) }'/>
           </sequence>
         </complexType>
@@ -405,7 +405,7 @@ SOFTWARE.
       <element name="key_token_group_PI" dfdl:lengthKind="implicit">
         <complexType>
           <sequence>
-            <element name="value" type="tns:presenceIndicator"
+            <element name="value" type="ms2045:presenceIndicator"
                      dfdl:outputValueCalc='{ fn:count(../../key_token_group) }'/>
           </sequence>
         </complexType>
@@ -419,7 +419,7 @@ SOFTWARE.
       <element name="authentication_data_a_group_PI" dfdl:lengthKind="implicit">
         <complexType>
           <sequence>
-            <element name="value" type="tns:presenceIndicator"
+            <element name="value" type="ms2045:presenceIndicator"
                      dfdl:outputValueCalc='{ fn:count(../../authentication_data_a_group) }'/>
           </sequence>
         </complexType>
@@ -432,7 +432,7 @@ SOFTWARE.
       <element name="authentication_data_b_group_PI" dfdl:lengthKind="implicit">
         <complexType>
           <sequence>
-            <element name="value" type="tns:presenceIndicator"
+            <element name="value" type="ms2045:presenceIndicator"
                      dfdl:outputValueCalc='{ fn:count(../../authentication_data_b_group) }'/>
           </sequence>
         </complexType>
@@ -445,7 +445,7 @@ SOFTWARE.
       <element name="message_security_padding_group_PI" dfdl:lengthKind="implicit">
         <complexType>
           <sequence>
-            <element name="value" type="tns:presenceIndicator"
+            <element name="value" type="ms2045:presenceIndicator"
                      dfdl:outputValueCalc='{ fn:count(../../message_security_padding_group) }'/>
           </sequence>
         </complexType>
@@ -458,7 +458,7 @@ SOFTWARE.
       <element name="message_security_padding_PI" dfdl:lengthKind="implicit">
         <complexType>
           <sequence>
-            <element name="value" type="tns:presenceIndicator"
+            <element name="value" type="ms2045:presenceIndicator"
                      dfdl:outputValueCalc='{ fn:count(../../message_security_padding) }'/>
           </sequence>
         </complexType>
@@ -472,7 +472,7 @@ SOFTWARE.
       <element name="message_subtype_PI" dfdl:lengthKind="implicit">
         <complexType>
           <sequence>
-            <element name="value" type="tns:presenceIndicator"
+            <element name="value" type="ms2045:presenceIndicator"
                      dfdl:outputValueCalc='{ fn:count(../../message_subtype) }'/>
           </sequence>
         </complexType>
@@ -485,7 +485,7 @@ SOFTWARE.
       <element name="cantco_reason_code_PI" dfdl:lengthKind="implicit">
         <complexType>
           <sequence>
-            <element name="value" type="tns:presenceIndicator"
+            <element name="value" type="ms2045:presenceIndicator"
                      dfdl:outputValueCalc='{ fn:count(../../cantco_reason_code) }'/>
           </sequence>
         </complexType>
@@ -499,7 +499,7 @@ SOFTWARE.
       <element name="cantpro_reason_code_PI" dfdl:lengthKind="implicit">
         <complexType>
           <sequence>
-            <element name="value" type="tns:presenceIndicator"
+            <element name="value" type="ms2045:presenceIndicator"
                      dfdl:outputValueCalc='{ fn:count(../../cantpro_reason_code) }'/>
           </sequence>
         </complexType>
@@ -512,7 +512,7 @@ SOFTWARE.
       <element name="reply_amplification_PI" dfdl:lengthKind="implicit">
         <complexType>
           <sequence>
-            <element name="value" type="tns:presenceIndicator"
+            <element name="value" type="ms2045:presenceIndicator"
                      dfdl:outputValueCalc='{ fn:count(../../reply_amplification) }'/>
           </sequence>
         </complexType>
@@ -527,7 +527,7 @@ SOFTWARE.
       <element name="control_release_marking_PI" dfdl:lengthKind="implicit">
         <complexType>
           <sequence>
-            <element name="value" type="tns:presenceIndicator"
+            <element name="value" type="ms2045:presenceIndicator"
                      dfdl:outputValueCalc='{
                        if (fn:exists(../../control_release_marking_D1))
                        then fn:count(../../control_release_marking_D1)

--- a/src/main/resources/com/owlcyberdefense/mil-std-2045/xsd/milstd2045_application_header.dfdl.xsd
+++ b/src/main/resources/com/owlcyberdefense/mil-std-2045/xsd/milstd2045_application_header.dfdl.xsd
@@ -35,7 +35,7 @@ SOFTWARE.
   xmlns:fn="http://www.w3.org/2005/xpath-functions"
   xmlns:msi="urn:milstd2045DFDLInternal"
   xmlns:msms="urn:milstd2045DFDLMessageSize"
-  xmlns:tns="urn:milstd2045DFDL"
+  xmlns:ms2045="urn:milstd2045DFDL"
   xmlns:xs="http://www.w3.org/2001/XMLSchema"
   xmlns="http://www.w3.org/2001/XMLSchema"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -50,7 +50,7 @@ SOFTWARE.
   <include schemaLocation="milstd2045_future_use_groups.dfdl.xsd"/>
   <annotation>
     <appinfo source="http://www.ogf.org/dfdl/">
-      <dfdl:format ref="tns:msCommon"/>
+      <dfdl:format ref="ms2045:msCommon"/>
       <dfdl:defineVariable name="hdrLen" type="xs:unsignedInt"/>
     </appinfo>
   </annotation>
@@ -59,7 +59,7 @@ SOFTWARE.
     <sequence>
       <annotation>
         <appinfo source="http://www.ogf.org/dfdl/">
-          <dfdl:newVariableInstance ref="tns:hdrLen"/>
+          <dfdl:newVariableInstance ref="ms2045:hdrLen"/>
         </appinfo>
       </annotation>
       <element name="contents">
@@ -68,14 +68,14 @@ SOFTWARE.
             <element name="version">
               <complexType>
                 <sequence>
-                  <element name="value" type="tns:versionEnum"/>
+                  <element name="value" type="ms2045:versionEnum"/>
                 </sequence>
               </complexType>
             </element>
             <sequence>
               <annotation>
                 <appinfo source="http://www.ogf.org/dfdl/">
-                  <dfdl:newVariableInstance ref="tns:versionSpec"
+                  <dfdl:newVariableInstance ref="ms2045:versionSpec"
                                             defaultValue="{ version/value }"/>
                 </appinfo>
               </annotation>
@@ -86,7 +86,7 @@ SOFTWARE.
                        dfdl:occursCount="{ ../data_compression_type_PI/value }">
                 <complexType>
                   <sequence>
-                    <element name="value" type="tns:dataCompressionEnum"/>
+                    <element name="value" type="ms2045:dataCompressionEnum"/>
                   </sequence>
                 </complexType>
               </element>
@@ -96,16 +96,16 @@ SOFTWARE.
                        dfdl:occursCountKind="expression"
                        dfdl:occursCount="{ ../originator_address_group_PI/value }">
                 <complexType>
-                  <group ref="tns:urn_unit_name_group"/>
+                  <group ref="ms2045:urn_unit_name_group"/>
                 </complexType>
               </element>
               <sequence dfdl:hiddenGroupRef="msi:recipient_address_group_PI"/>
-              <element name="recipient_address_group" type="tns:address_group_type"
+              <element name="recipient_address_group" type="ms2045:address_group_type"
                        minOccurs="0" maxOccurs="16"
                        dfdl:occursCountKind="expression"
                        dfdl:occursCount="{ ../recipient_address_group_PI/value }"/>
               <sequence dfdl:hiddenGroupRef="msi:information_address_group_PI"/>
-              <element name="information_address_group" type="tns:address_group_type"
+              <element name="information_address_group" type="ms2045:address_group_type"
                        minOccurs="0" maxOccurs="16"
                        dfdl:occursCountKind="expression"
                        dfdl:occursCount="{ ../information_address_group_PI/value }"/>
@@ -120,7 +120,7 @@ SOFTWARE.
                }'>
                 <complexType>
                   <sequence>
-                    <element name="value" type="tns:invalidEnum"
+                    <element name="value" type="ms2045:invalidEnum"
                              dfdl:inputValueCalc='{
                              fn:concat("Too many address groups. Max of 16 for combination of recipient_address_group(",
                                        fn:count(../../recipient_address_group[1]/item),
@@ -138,12 +138,12 @@ SOFTWARE.
                        dfdl:occursCount="{ ../header_size_PI/value }">
                 <complexType>
                   <sequence>
-                    <element name="value" type="tns:tIntField" dfdl:length="16"
-                             dfdl:outputValueCalc="{ $tns:hdrLen }"/>
+                    <element name="value" type="ms2045:tIntField" dfdl:length="16"
+                             dfdl:outputValueCalc="{ $ms2045:hdrLen }"/>
                   </sequence>
                 </complexType>
               </element>
-              <group ref="tns:futureUseGroup"/>
+              <group ref="ms2045:futureUseGroup"/>
               <!-- start message handling group -->
               <element name="message_handling_group">
                 <complexType>
@@ -157,7 +157,7 @@ SOFTWARE.
                           <element name="umf">
                             <complexType>
                               <sequence>
-                                <element name="value" type="tns:umfEnum"/>
+                                <element name="value" type="ms2045:umfEnum"/>
                               </sequence>
                             </complexType>
                           </element>
@@ -189,7 +189,7 @@ SOFTWARE.
                             <complexType>
                               <choice dfdl:choiceDispatchKey="{ ../umf/value }">
                                 <element dfdl:choiceBranchKey="OK_Link_16" name="link16"
-                                         type="tns:messsageStandardVersionLink16Enum"/>
+                                         type="ms2045:messsageStandardVersionLink16Enum"/>
                                 <!--
                                 A real use case is binary files where those files carry
                                 a VMF binary message.
@@ -198,15 +198,15 @@ SOFTWARE.
                                 the version of that VMF message.
                                 -->
                                 <group  dfdl:choiceBranchKey="OK_VMF OK_Binary_File"
-                                        ref="tns:messageStandardVersionVMFGroup"/>
+                                        ref="ms2045:messageStandardVersionVMFGroup"/>
                                 <element dfdl:choiceBranchKey="OK_NITFS" name="nitfs"
-                                         type="tns:messsageStandardVersionNITFSEnum"/>
+                                         type="ms2045:messsageStandardVersionNITFSEnum"/>
                                 <element dfdl:choiceBranchKey="OK_USMTF" name="usmtf"
-                                         type="tns:messsageStandardVersionUSMTFEnum"/>
+                                         type="ms2045:messsageStandardVersionUSMTFEnum"/>
                                 <element dfdl:choiceBranchKey="OK_XML-MTF" name="xml-mtf"
-                                         type="tns:messsageStandardVersionXML_MTFEnum"/>
+                                         type="ms2045:messsageStandardVersionXML_MTFEnum"/>
                                 <group dfdl:choiceBranchKey="OK_XML-VMF"
-                                         ref="tns:messageStandardVersionXMLVMFGroup"/>
+                                         ref="ms2045:messageStandardVersionXMLVMFGroup"/>
                               </choice>
                             </complexType>
                           </element>
@@ -220,7 +220,7 @@ SOFTWARE.
                                 <element name="fad">
                                   <complexType>
                                     <sequence>
-                                      <element name="value" type="tns:tIntField"
+                                      <element name="value" type="ms2045:tIntField"
                                                dfdl:length="4"/>
                                     </sequence>
                                   </complexType>
@@ -228,7 +228,7 @@ SOFTWARE.
                                 <element name="message_number">
                                   <complexType>
                                     <sequence>
-                                      <element name="value" type="tns:tIntField"
+                                      <element name="value" type="ms2045:tIntField"
                                                dfdl:length="7"/>
                                     </sequence>
                                   </complexType>
@@ -240,12 +240,12 @@ SOFTWARE.
                                          dfdl:occursCount="{ ../message_subtype_PI/value }">
                                   <complexType>
                                     <sequence>
-                                      <element name="value" type="tns:tIntField"
+                                      <element name="value" type="ms2045:tIntField"
                                                dfdl:length="7"/>
                                     </sequence>
                                   </complexType>
                                 </element>
-                                <element name="K_ID" type="tns:K_ID"
+                                <element name="K_ID" type="ms2045:K_ID"
                                          dfdl:inputValueCalc='{
                                    fn:concat(
                                      "K",
@@ -281,14 +281,14 @@ SOFTWARE.
                           <element name="operation_indicator">
                             <complexType>
                               <sequence>
-                                <element name="value" type="tns:operationIndicatorEnum"/>
+                                <element name="value" type="ms2045:operationIndicatorEnum"/>
                               </sequence>
                             </complexType>
                           </element>
                           <element name="retransmit_indicator">
                             <complexType>
                               <sequence>
-                                <element name="value" type="tns:retransmitIndicatorEnum"/>
+                                <element name="value" type="ms2045:retransmitIndicatorEnum"/>
                               </sequence>
                             </complexType>
                           </element>
@@ -296,7 +296,7 @@ SOFTWARE.
                           <element name="message_precedence_codes">
                             <complexType>
                               <sequence>
-                                <group ref="tns:messagePrecedenceCodesGroup"/>
+                                <group ref="ms2045:messagePrecedenceCodesGroup"/>
                               </sequence>
                             </complexType>
                           </element>
@@ -304,12 +304,12 @@ SOFTWARE.
                           <element name="security_classification">
                             <complexType>
                               <sequence>
-                                <element name="value" type="tns:securityClassificationEnum"/>
+                                <element name="value" type="ms2045:securityClassificationEnum"/>
                               </sequence>
                             </complexType>
                           </element>
                           <sequence dfdl:hiddenGroupRef="msi:control_release_marking_PI"/>
-                          <choice dfdl:choiceDispatchKey="{ $tns:versionSpec }">
+                          <choice dfdl:choiceDispatchKey="{ $ms2045:versionSpec }">
                             <sequence dfdl:choiceBranchKey="D1">
                               <element
                                 name="control_release_marking_D1"
@@ -324,7 +324,7 @@ SOFTWARE.
                                       <complexType>
                                         <sequence>
                                           <sequence dfdl:hiddenGroupRef="msi:FRI_discriminator"/>
-                                          <element name="value" type="tns:dfi4127_dui005_nationality_Enum"/>
+                                          <element name="value" type="ms2045:dfi4127_dui005_nationality_Enum"/>
                                         </sequence>
                                       </complexType>
                                     </element>
@@ -349,7 +349,7 @@ SOFTWARE.
                                    dfdl:occursCountKind="expression"
                                    dfdl:occursCount="{ ../originator_dtg_group_PI/value }">
                             <complexType>
-                              <group ref="tns:dtg_group"/>
+                              <group ref="ms2045:dtg_group"/>
                             </complexType>
                           </element>
                           <sequence dfdl:hiddenGroupRef="msi:perishability_dtg_group_PI"/>
@@ -358,7 +358,7 @@ SOFTWARE.
                                    dfdl:occursCountKind="expression"
                                    dfdl:occursCount="{ ../perishability_dtg_group_PI/value }">
                             <complexType>
-                              <group ref="tns:dateTime"/>
+                              <group ref="ms2045:dateTime"/>
                             </complexType>
                           </element>
                           <sequence dfdl:hiddenGroupRef="msi:acknowledgement_request_group_PI"/>
@@ -371,21 +371,21 @@ SOFTWARE.
                                 <element name="machine_acknowledge_request_indicator">
                                   <complexType>
                                     <sequence>
-                                      <element name="value" type="tns:acknowledgeRequestIndicatorEnum"/>
+                                      <element name="value" type="ms2045:acknowledgeRequestIndicatorEnum"/>
                                     </sequence>
                                   </complexType>
                                 </element>
                                 <element name="operator_acknowledge_request_indicator">
                                   <complexType>
                                     <sequence>
-                                      <element name="value" type="tns:acknowledgeRequestIndicatorEnum"/>
+                                      <element name="value" type="ms2045:acknowledgeRequestIndicatorEnum"/>
                                     </sequence>
                                   </complexType>
                                 </element>
                                 <element name="operator_reply_request_indicator">
                                   <complexType>
                                     <sequence>
-                                      <element name="value" type="tns:replyRequestIndicatorEnum"/>
+                                      <element name="value" type="ms2045:replyRequestIndicatorEnum"/>
                                     </sequence>
                                   </complexType>
                                 </element>
@@ -399,11 +399,11 @@ SOFTWARE.
                                    dfdl:occursCount="{ ../response_data_group_PI/value }">
                             <complexType>
                               <sequence>
-                                <group ref="tns:dtg_group"/>
+                                <group ref="ms2045:dtg_group"/>
                                 <element name="r_c">
                                   <complexType>
                                     <sequence>
-                                      <element name="value" type="tns:receiptComplianceEnum"/>
+                                      <element name="value" type="ms2045:receiptComplianceEnum"/>
                                     </sequence>
                                   </complexType>
                                 </element>
@@ -414,7 +414,7 @@ SOFTWARE.
                                          dfdl:occursCount="{ ../cantco_reason_code_PI/value }">
                                   <complexType>
                                     <sequence>
-                                      <element name="value" type="tns:cantcoReasonCodewordsEnum"/>
+                                      <element name="value" type="ms2045:cantcoReasonCodewordsEnum"/>
                                     </sequence>
                                   </complexType>
                                 </element>
@@ -425,7 +425,7 @@ SOFTWARE.
                                          dfdl:occursCount="{ ../cantpro_reason_code_PI/value }">
                                   <complexType>
                                     <sequence>
-                                      <element name="value" type="tns:cantproReasonCodewordsEnum"/>
+                                      <element name="value" type="ms2045:cantproReasonCodewordsEnum"/>
                                     </sequence>
                                   </complexType>
                                 </element>
@@ -454,23 +454,23 @@ SOFTWARE.
                                   <complexType>
                                     <sequence>
                                       <sequence dfdl:hiddenGroupRef="msi:GRI_discriminator"/>
-                                      <group ref="tns:urn_unit_name_group"/>
-                                      <group ref="tns:dtg_group"/>
+                                      <group ref="ms2045:urn_unit_name_group"/>
+                                      <group ref="ms2045:dtg_group"/>
                                     </sequence>
                                   </complexType>
                                 </element>
                               </sequence>
                             </complexType>
                           </element>
-                          <group ref="tns:futureUseGroup"/>
-                          <group ref="tns:message_security_group"/>
+                          <group ref="ms2045:futureUseGroup"/>
+                          <group ref="ms2045:message_security_group"/>
                         </sequence>
                       </complexType>
                     </element>
                   </sequence>
                 </complexType>
               </element>
-              <group ref="tns:futureUseGroup"/>
+              <group ref="ms2045:futureUseGroup"/>
               <!-- end message handling group -->
               <sequence dfdl:alignment="1" dfdl:alignmentUnits="bytes"/>
             </sequence>
@@ -488,7 +488,7 @@ SOFTWARE.
             after this. To get the header size when parsing you must access the element via a path
             expression.
             -->
-            <dfdl:setVariable ref="tns:hdrLen" value="{ dfdl:valueLength(contents, 'bytes') }"/>
+            <dfdl:setVariable ref="ms2045:hdrLen" value="{ dfdl:valueLength(contents, 'bytes') }"/>
           </appinfo>
         </annotation>
       </sequence>
@@ -499,7 +499,7 @@ SOFTWARE.
     in the spec. -->
   <element name="message_security_group_with_PI">
     <complexType>
-      <group ref="tns:message_security_group"/>
+      <group ref="ms2045:message_security_group"/>
     </complexType>
   </element>
 
@@ -515,7 +515,7 @@ SOFTWARE.
             <element name="security_parameters_information">
               <complexType>
                 <sequence>
-                  <element name="value" type="tns:securityParameterInformationEnum"/>
+                  <element name="value" type="ms2045:securityParameterInformationEnum"/>
                 </sequence>
               </complexType>
             </element>
@@ -529,7 +529,7 @@ SOFTWARE.
                   <element name="keying_material_id_length">
                     <complexType>
                       <sequence>
-                        <element name="value" type="tns:tIntField" dfdl:length="3"
+                        <element name="value" type="ms2045:tIntField" dfdl:length="3"
                                  dfdl:outputValueCalc="{ dfdl:valueLength(../../keying_material_id/value, 'bytes') - 1 }"/>
                       </sequence>
                     </complexType>
@@ -537,7 +537,7 @@ SOFTWARE.
                   <element name="keying_material_id">
                     <complexType>
                       <sequence>
-                        <element name="value" type="tns:tHexBinary"
+                        <element name="value" type="ms2045:tHexBinary"
                                  dfdl:length="{ ../../keying_material_id_length/value + 1 }"
                                  dfdl:lengthUnits="bytes"/>
                       </sequence>
@@ -556,7 +556,7 @@ SOFTWARE.
                   <element name="cryptographic_initialization_length">
                     <complexType>
                       <sequence>
-                        <element name="value" type="tns:tIntField" dfdl:length="4"
+                        <element name="value" type="ms2045:tIntField" dfdl:length="4"
                                  dfdl:outputValueCalc="{ (dfdl:valueLength(../../cryptographic_initialization/value, 'bytes') idiv 8) - 1 }"/>
                       </sequence>
                     </complexType>
@@ -564,7 +564,7 @@ SOFTWARE.
                   <element name="cryptographic_initialization">
                     <complexType>
                       <sequence>
-                        <element name="value" type="tns:tHexBinary"
+                        <element name="value" type="ms2045:tHexBinary"
                                  dfdl:length="{ (../../cryptographic_initialization_length/value + 1) * 8 }"
                                  dfdl:lengthUnits="bytes"/>
                       </sequence>
@@ -583,7 +583,7 @@ SOFTWARE.
                   <element name="key_token_length">
                     <complexType>
                       <sequence>
-                        <element name="value" type="tns:tIntField" dfdl:length="8"
+                        <element name="value" type="ms2045:tIntField" dfdl:length="8"
                                  dfdl:outputValueCalc="{ (dfdl:valueLength(../../key_token/item[1]/value, 'bytes') idiv 8) - 1 }"/>
                       </sequence>
                     </complexType>
@@ -597,7 +597,7 @@ SOFTWARE.
                           <complexType>
                             <sequence>
                               <sequence dfdl:hiddenGroupRef="msi:FRI_discriminator"/>
-                              <element name="value" type="tns:tHexBinary"
+                              <element name="value" type="ms2045:tHexBinary"
                                        dfdl:length="{ (../../../key_token_length/value + 1) * 8 }"
                                        dfdl:lengthUnits="bytes"/>
                             </sequence>
@@ -610,19 +610,19 @@ SOFTWARE.
               </complexType>
             </element>
             <sequence dfdl:hiddenGroupRef="msi:authentication_data_a_group_PI"/>
-            <element name="authentication_data_a_group" type="tns:authentication_data"
+            <element name="authentication_data_a_group" type="ms2045:authentication_data"
                      minOccurs="0"
                      dfdl:occursCountKind="expression"
                      dfdl:occursCount="{ ../authentication_data_a_group_PI/value }"/>
             <sequence dfdl:hiddenGroupRef="msi:authentication_data_b_group_PI"/>
-            <element name="authentication_data_b_group" type="tns:authentication_data"
+            <element name="authentication_data_b_group" type="ms2045:authentication_data"
                      minOccurs="0"
                      dfdl:occursCountKind="expression"
                      dfdl:occursCount="{ ../authentication_data_b_group_PI/value }"/>
             <element name="signed_acknowledge_request_indicator">
               <complexType>
                 <sequence>
-                  <element name="value" type="tns:signedAcknowledgeRequestIndicatorEnum"/>
+                  <element name="value" type="ms2045:signedAcknowledgeRequestIndicatorEnum"/>
                 </sequence>
               </complexType>
             </element>
@@ -636,7 +636,7 @@ SOFTWARE.
                   <element name="message_security_padding_length">
                     <complexType>
                       <sequence>
-                        <element name="value" type="tns:tIntField" dfdl:length="8"
+                        <element name="value" type="ms2045:tIntField" dfdl:length="8"
                                  dfdl:outputValueCalc="{
                                         if (fn:exists(../../message_security_padding[1]))
                                         then (dfdl:valueLength(../../message_security_padding[1]/value, 'bits') idiv 8)
@@ -651,7 +651,7 @@ SOFTWARE.
                            dfdl:occursCount="{ ../message_security_padding_PI/value }">
                     <complexType>
                       <sequence>
-                        <element name="value" type="tns:tHexBinary"
+                        <element name="value" type="ms2045:tHexBinary"
                                  dfdl:length="{ ../../message_security_padding_length/value }"
                                  dfdl:lengthUnits="bytes"/>
                       </sequence>

--- a/src/main/resources/com/owlcyberdefense/mil-std-2045/xsd/milstd2045_future_use_groups.dfdl.xsd
+++ b/src/main/resources/com/owlcyberdefense/mil-std-2045/xsd/milstd2045_future_use_groups.dfdl.xsd
@@ -35,7 +35,7 @@ SOFTWARE.
   xmlns:fn="http://www.w3.org/2005/xpath-functions"
   xmlns:msi="urn:milstd2045DFDLInternal"
   xmlns:msms="urn:milstd2045DFDLMessageSize"
-  xmlns:tns="urn:milstd2045DFDL"
+  xmlns:ms2045="urn:milstd2045DFDL"
   xmlns:xs="http://www.w3.org/2001/XMLSchema"
   xmlns="http://www.w3.org/2001/XMLSchema"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -47,27 +47,27 @@ SOFTWARE.
 
   <annotation>
     <appinfo source="http://www.ogf.org/dfdl/">
-      <dfdl:format ref="tns:msCommon"/>
+      <dfdl:format ref="ms2045:msCommon"/>
       <dfdl:defineVariable name="versionSpec" type="xs:string"/>
     </appinfo>
   </annotation>
 
   <group name="futureUseGroup">
     <sequence>
-      <element name="future" type="tns:future"
+      <element name="future" type="ms2045:future"
                minOccurs="0"
                dfdl:occursCountKind="expression"
-               dfdl:occursCount="{ if ($tns:versionSpec eq 'D1') then 1 else 0 }"/>
+               dfdl:occursCount="{ if ($ms2045:versionSpec eq 'D1') then 1 else 0 }"/>
     </sequence>
   </group>
 
   <complexType name="future">
     <sequence>
-      <sequence dfdl:hiddenGroupRef="tns:future_use_1_PI"/>
-      <sequence dfdl:hiddenGroupRef="tns:future_use_2_PI"/>
-      <sequence dfdl:hiddenGroupRef="tns:future_use_3_PI"/>
-      <sequence dfdl:hiddenGroupRef="tns:future_use_4_PI"/>
-      <sequence dfdl:hiddenGroupRef="tns:future_use_5_PI"/>
+      <sequence dfdl:hiddenGroupRef="ms2045:future_use_1_PI"/>
+      <sequence dfdl:hiddenGroupRef="ms2045:future_use_2_PI"/>
+      <sequence dfdl:hiddenGroupRef="ms2045:future_use_3_PI"/>
+      <sequence dfdl:hiddenGroupRef="ms2045:future_use_4_PI"/>
+      <sequence dfdl:hiddenGroupRef="ms2045:future_use_5_PI"/>
     </sequence>
   </complexType>
 

--- a/src/test/resources/com/owlcyberdefense/mil-std-2045/xsd/milstd2045_message_size.dfdl.xsd
+++ b/src/test/resources/com/owlcyberdefense/mil-std-2045/xsd/milstd2045_message_size.dfdl.xsd
@@ -30,7 +30,7 @@ SOFTWARE.
 -->
 <schema
   targetNamespace="urn:milstd2045DFDLMessageSize"
-  xmlns:tns="urn:milstd2045DFDLMessageSize"
+  xmlns:ms2045="urn:milstd2045DFDLMessageSize"
   xmlns:xs="http://www.w3.org/2001/XMLSchema"
   xmlns="http://www.w3.org/2001/XMLSchema"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"


### PR DESCRIPTION
This convention, while seemingly convenient, causes problems trying to figure out the data, particularly when this schema is combined with other schemas that also use the tns: convention.