### PR TITLE
Version 1.3.0 - Remediate XSAT2 scan findings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,32 @@ The src/test/resources/milstd2045.tdml file contains unit tests with test data.
 Note that this DFDL schema requires the dfdl:bitOrder format property. 
 As such it works only with Daffodil and not IBM DFDL. (as of this writing - 2022-03-12)
 
+## XSAT2 Schema Quality Report
+
+The schema has been scanned with the XSAT2 Schema Quality Tool.
+The report is below:
+
+    ***************************************
+    * XSAT2 Schema Quality Checker Report  *
+    * File(s) processed: 9 
+    ****************************************
+    In File: /milstd2045.common.dfdl.xsd
+
+     Test 'Base64Binary or hexBinary' Line 76, Col 6, Section: 3.19, Risk Level: High
+     Description: Remove the element or attribute with the binary data.
+     Non-Remediation Reason:
+        This hexBinary type is used only for crypographic-related fields which are
+        documented in the mil-std-2045 spec. as just byte strings. The fields are:
+        * authentication_data,
+        * keying_material_id,
+        * cryptographic_initialization,
+        * key_token,
+        * message_security_padding
+
+    ****************************************
+    *          End XSAT2 Report            *
+    ****************************************
+
+
+
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "dfdl-mil-std-2045"
 
 organization := "com.owlcyberdefense"
 
-version := "1.2.0"
+version := "1.3.0"
 
 scalaVersion := "2.12.17"
 
@@ -10,7 +10,10 @@ libraryDependencies ++= Seq(
   "org.apache.daffodil" %% "daffodil-tdml-processor" % "3.4.0" % "test",
   "junit" % "junit" % "4.13.2" % "test",
   "com.github.sbt" % "junit-interface" % "0.13.3" % "test",
-  "org.apache.logging.log4j" % "log4j-core" % "2.19.0" % "test"
+  "org.apache.logging.log4j" % "log4j-core" % "2.19.0" % "test",
+  // XSAT2 If you have access to the XSAT2 tool, and wish to run it:
+  // Uncomment the line below to run XSAT via the method TestWithXSAT2.test_xsat2_schema
+  // "owl" % "xsat-owl" % "0.1.0-SNAPSHOT" % "test",
 )
 
 testOptions += Tests.Argument(TestFrameworks.JUnit, "-v")

--- a/src/main/resources/com/owlcyberdefense/mil-std-2045/xsd/milstd2045.common.dfdl.xsd
+++ b/src/main/resources/com/owlcyberdefense/mil-std-2045/xsd/milstd2045.common.dfdl.xsd
@@ -73,12 +73,28 @@ SOFTWARE.
   </simpleType>
 
   <simpleType name="tHexBinary" dfdl:lengthKind="explicit">
-    <restriction base="xs:hexBinary"/>
+    <restriction base="xs:hexBinary">
+    <annotation>
+      <appinfo source="urn:com.owlcyberdefense.xsat2">
+        <xsat2>
+          <nonRemediation>
+            This hexBinary type is used only for crypographic-related fields which are
+            documented in the mil-std-2045 spec. as just byte strings. The fields are:
+            * authentication_data,
+            * keying_material_id,
+            * cryptographic_initialization,
+            * key_token,
+            * message_security_padding
+          </nonRemediation>
+        </xsat2>
+      </appinfo>
+    </annotation>
+    </restriction>
   </simpleType>
 
   <simpleType name="K_ID">
     <restriction base="xs:string">
-      <pattern value="K\d\d\.\d\d(.\d{1,3})?"/>
+      <pattern value="K[0-9][0-9]\.[0-9][0-9](\.[0-9]{1,3})?"/>
     </restriction>
   </simpleType>
 

--- a/src/main/resources/com/owlcyberdefense/mil-std-2045/xsd/milstd2045.enums.dfdl.xsd
+++ b/src/main/resources/com/owlcyberdefense/mil-std-2045/xsd/milstd2045.enums.dfdl.xsd
@@ -112,7 +112,7 @@ SOFTWARE.
   -->
   <simpleType name="invalidEnum">
     <restriction base="xs:string">
-      <pattern value="OK_.{0,300}"/>
+      <pattern value="OK_[0-9A-Za-z_-]{0,300}"/>
     </restriction>
   </simpleType>
 
@@ -142,7 +142,7 @@ SOFTWARE.
     <restriction base="ms2045:enumString">
       <enumeration value="LZW" dfdlx:repValues="0"/>
       <enumeration value="GZIP" dfdlx:repValues="1"/>
-      <pattern value="OK_.{0,20}"/><!-- none of these are implemented yet -->
+      <pattern value="OK_[0-9A-Za-z_-]{0,20}"/><!-- none of these are implemented yet -->
     </restriction>
   </simpleType>
 
@@ -161,7 +161,7 @@ SOFTWARE.
       This pattern facet insures that only the above "OK" values are
       considered valid.
       -->
-      <pattern value="OK_.{0,20}"/>
+      <pattern value="OK_[0-9A-Za-z_-]{0,20}"/>
       <!--
       The remaining enums don't have OK_ prefixes, so will be
       considered well-formed, but won't pass validation, as
@@ -249,7 +249,7 @@ SOFTWARE.
       <enumeration value="Reserved_13" dfdlx:repValues="13"/>
       <enumeration value="Reserved_14" dfdlx:repValues="14"/>
       <enumeration value="Reserved_15" dfdlx:repValues="15"/>
-      <pattern value="OK_.{0,20}"/>
+      <pattern value="OK_[0-9A-Za-z_-]{0,20}"/>
     </restriction>
   </simpleType>
 
@@ -277,7 +277,7 @@ SOFTWARE.
       <enumeration value="Reserved_13" dfdlx:repValues="13"/>
       <enumeration value="Reserved_14" dfdlx:repValues="14"/>
       <enumeration value="Reserved_15" dfdlx:repValues="15"/>
-      <pattern value="OK_.{0,20}"/>
+      <pattern value="OK_[0-9A-Za-z_-]{0,20}"/>
     </restriction>
   </simpleType>
 
@@ -289,7 +289,7 @@ SOFTWARE.
       This pattern facet insures that only the above "OK" values are
       considered valid.
       -->
-      <pattern value="OK_.{0,20}"/>
+      <pattern value="OK_[0-9A-Za-z_-]{0,20}"/>
       <!--
       The remaining enums don't have OK_ prefixes, so will be
       considered well-formed, but won't pass validation, as
@@ -347,7 +347,7 @@ SOFTWARE.
       This pattern facet insures that only the above "OK" values are
       considered valid.
       -->
-      <pattern value="OK_.{0,20}"/>
+      <pattern value="OK_[0-9A-Za-z_-]{0,20}"/>
       <!--
       The remaining enums don't have OK_ prefixes, so will be
       considered well-formed, but won't pass validation, as
@@ -419,7 +419,7 @@ SOFTWARE.
       <enumeration value="Reserved_13" dfdlx:repValues="13"/>
       <enumeration value="Reserved_14" dfdlx:repValues="14"/>
       <enumeration value="Reserved_15" dfdlx:repValues="15"/>
-      <pattern value="OK_.{0,20}"/>
+      <pattern value="OK_[0-9A-Za-z_-]{0,20}"/>
     </restriction>
   </simpleType>
 
@@ -445,7 +445,7 @@ SOFTWARE.
       <enumeration value="Reserved_13" dfdlx:repValues="13"/>
       <enumeration value="Reserved_14" dfdlx:repValues="14"/>
       <enumeration value="Reserved_15" dfdlx:repValues="15"/>
-      <pattern value="OK_.{0,20}"/>
+      <pattern value="OK_[0-9A-Za-z_-]{0,20}"/>
     </restriction>
   </simpleType>
 
@@ -502,7 +502,7 @@ SOFTWARE.
       This pattern facet insures that only the above "OK" values are
       considered valid.
       -->
-      <pattern value="OK_.{0,100}"/>
+      <pattern value="OK_[0-9A-Za-z_-]{0,100}"/>
       <!--
       The remaining enums don't have OK_ prefixes, so will be
       considered well-formed, but won't pass validation, as
@@ -597,7 +597,7 @@ SOFTWARE.
       This pattern facet insures that only the above "OK" values are
       considered valid.
       -->
-      <pattern value="OK_.{0,20}"/>
+      <pattern value="OK_[0-9A-Za-z_-]{0,20}"/>
       <!--
       The remaining enums don't have OK_ prefixes, so will be
       considered well-formed, but won't pass validation, as
@@ -622,7 +622,7 @@ SOFTWARE.
       This pattern facet insures that only the above "OK" values are
       considered valid.
       -->
-      <pattern value="OK_.{0,20}"/>
+      <pattern value="OK_[0-9A-Za-z_-]{0,20}"/>
       <!--
       The remaining enums don't have OK_ prefixes, so will be
       considered well-formed, but won't pass validation, as
@@ -656,7 +656,7 @@ SOFTWARE.
       This pattern facet insures that only the above "OK" values are
       considered valid.
       -->
-      <pattern value="OK_.{0,20}"/>
+      <pattern value="OK_[0-9A-Za-z_-]{0,20}"/>
       <!--
       The remaining enums don't have OK_ prefixes, so will be
       considered well-formed, but won't pass validation, as
@@ -674,7 +674,7 @@ SOFTWARE.
       This pattern facet insures that only the above "OK" values are
       considered valid.
       -->
-      <pattern value="OK_.{0,100}"/>
+      <pattern value="OK_[0-9A-Za-z_-]{0,100}"/>
       <!--
       The remaining enums don't have OK_ prefixes, so will be
       considered well-formed, but won't pass validation, as

--- a/src/test/scala/com/owlcyberdefense/mil_std_2045/TestWithXSAT2.scala
+++ b/src/test/scala/com/owlcyberdefense/mil_std_2045/TestWithXSAT2.scala
@@ -1,0 +1,20 @@
+package com.owlcyberdefense.mil_std_2045
+
+import org.apache.daffodil.util.Misc
+import org.junit.{Ignore, Test}
+
+import java.io.File
+
+class TestWithXSAT2 {
+
+  @Ignore("Use to run XSAT2 report manually.")
+  @Test
+  def test_xsat2_schema(): Unit = {
+    val schemaURI = Misc.getRequiredResource("com/owlcyberdefense/mil-std-2045/xsd/milstd2045_application_header.dfdl.xsd")
+    val schemaFile = new File(schemaURI)
+    val schemaFilePath = schemaFile.toString
+    // For XSAT2, Uncomment the line below, and the corresponding line in the built.sbt.
+    // com.owlcyberdefense.xsat2.XSAT2SchemaQualityChecker.XSAT2SchemaQualityChecker.doXSAT2(schemaFilePath)
+  }
+
+}


### PR DESCRIPTION
One issue is non-remediated - use of hexBinary type for cryptographic-related fields.

XSAT2 Report was appended to the README.md file.