### PR TITLE
Refactor build and schema definitions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,11 @@
-name := "dfdl-mil-std-2045"
-
-organization := "com.owlcyberdefense"
-
-version := "1.3.3"
-
-daffodilVersion := "4.0.0"
-
-enablePlugins(DaffodilPlugin)
+val root = (project in file("."))
+  .settings(
+    name := "dfdl-mil-std-2045",
+    organization := "com.owlcyberdefense",
+    version := "1.3.3",
+    daffodilVersion := "4.1.0",
+    Seq(packageBin, packageSrc, packageDoc).map { task =>
+      Compile / task / mappings += (baseDirectory.value / "COPYRIGHT.txt") -> "COPYRIGHT.txt"
+    }
+  )
+  .daffodilProject(crossDaffodilVersions = Seq("3.6.0", "3.7.0", "3.8.0", "3.9.0", "3.10.0", "3.11.0", "4.0.0"))

--- a/src/main/resources/com/owlcyberdefense/mil-std-2045/xsd/milstd2045.common.dfdl.xsd
+++ b/src/main/resources/com/owlcyberdefense/mil-std-2045/xsd/milstd2045.common.dfdl.xsd
@@ -32,6 +32,7 @@ SOFTWARE.
 <schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
         xmlns="http://www.w3.org/2001/XMLSchema"
         xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+        xmlns:fn="http://www.w3.org/2005/xpath-functions"
         xmlns:ms2045="urn:milstd2045DFDL"
         targetNamespace="urn:milstd2045DFDL">
 
@@ -88,6 +89,33 @@ SOFTWARE.
     </restriction>
   </simpleType>
 
+  <simpleType name="checkedInt" dfdl:lengthKind="explicit">
+    <annotation>
+      <appinfo source="http://www.ogf.org/dfdl/">
+        <dfdl:assert
+            message='{ fn:concat("The value: ", xs:string(.) , " did not satisfy facet constraints.") }'>{
+          dfdl:checkConstraints(.) }</dfdl:assert>
+      </appinfo>
+    </annotation>
+    <restriction base="xs:unsignedInt"/>
+  </simpleType>
+
+  <!--
+  Used to create invalid element values on purpose.
+
+  Any string that doesn't begin with "OK_" will be deemed
+  invalid and generate a validation error.
+
+  Some of these invalid elements use a dfdl:inputValueCalc to
+  capture a diagnostic message. These can be a few lines
+  long. Hence, fairly large max for this.
+  -->
+  <simpleType name="invalidEnum">
+    <restriction base="xs:string">
+      <pattern value="OK_[0-9A-Za-z_-]{0,300}"/>
+    </restriction>
+  </simpleType>
+
   <complexType name="address_group_type">
     <sequence>
       <element name="item"
@@ -135,24 +163,6 @@ SOFTWARE.
           <sequence>
             <element name="value" type="ms2045:invalidEnum"
                      dfdl:inputValueCalc='{ "both URN and unit_name exist" }'/>
-          </sequence>
-        </complexType>
-      </element>
-    </sequence>
-  </group>
-
-  <group name="dtg_group">
-    <sequence>
-      <group ref="ms2045:dateTime"/>
-      <sequence dfdl:hiddenGroupRef="ms2045:dtg_extension_PI"/>
-      <element name="dtg_extension"
-               minOccurs="0"
-               dfdl:occursCountKind="expression"
-               dfdl:occursCount="{ ../dtg_extension_PI/value }">
-        <complexType>
-          <sequence>
-            <element name="value" type="ms2045:tIntField"
-                     dfdl:length="12"/>
           </sequence>
         </complexType>
       </element>

--- a/src/main/resources/com/owlcyberdefense/mil-std-2045/xsd/milstd2045.dateTime.dfdl.xsd
+++ b/src/main/resources/com/owlcyberdefense/mil-std-2045/xsd/milstd2045.dateTime.dfdl.xsd
@@ -69,6 +69,24 @@ SOFTWARE.
     <restriction base="xs:string"/>
   </simpleType>
 
+  <group name="dtg_group">
+    <sequence>
+      <group ref="ms2045:dateTime"/>
+      <sequence dfdl:hiddenGroupRef="ms2045:dtg_extension_PI"/>
+      <element name="dtg_extension"
+               minOccurs="0"
+               dfdl:occursCountKind="expression"
+               dfdl:occursCount="{ ../dtg_extension_PI/value }">
+        <complexType>
+          <sequence>
+            <element name="value" type="ms2045:tIntField"
+                     dfdl:length="12"/>
+          </sequence>
+        </complexType>
+      </element>
+    </sequence>
+  </group>
+
   <group name="dateTime">
     <sequence>
       <sequence dfdl:hiddenGroupRef="ms2045:ymdhms"/>

--- a/src/main/resources/com/owlcyberdefense/mil-std-2045/xsd/milstd2045.enums.dfdl.xsd
+++ b/src/main/resources/com/owlcyberdefense/mil-std-2045/xsd/milstd2045.enums.dfdl.xsd
@@ -45,17 +45,6 @@ SOFTWARE.
     </appinfo>
   </annotation>
 
-  <simpleType name="checkedInt" dfdl:lengthKind="explicit">
-    <annotation>
-      <appinfo source="http://www.ogf.org/dfdl/">
-        <dfdl:assert
-          message='{ fn:concat("The value: ", xs:string(.) , " did not satisfy facet constraints.") }'>{
-          dfdl:checkConstraints(.) }</dfdl:assert>
-      </appinfo>
-    </annotation>
-    <restriction base="xs:unsignedInt"/>
-  </simpleType>
-
   <simpleType name="enumBase">
     <restriction base="ms2045:checkedInt"/>
   </simpleType>
@@ -101,22 +90,6 @@ SOFTWARE.
   <xs:simpleType name="enumString" dfdl:lengthKind="delimited">
     <xs:restriction base="xs:string"/>
   </xs:simpleType>
-
-  <!--
-  Used to create invalid element values on purpose.
-
-  Any string that doesn't begin with "OK_" will be deemed
-  invalid and generate a validation error.
-
-  Some of these invalid elements use a dfdl:inputValueCalc to
-  capture a diagnostic message. These can be a few lines
-  long. Hence, fairly large max for this.
-  -->
-  <simpleType name="invalidEnum">
-    <restriction base="xs:string">
-      <pattern value="OK_[0-9A-Za-z_-]{0,300}"/>
-    </restriction>
-  </simpleType>
 
   <simpleType name="versionEnum" dfdlx:repType="ms2045:enum4">
     <restriction base="ms2045:enumString">


### PR DESCRIPTION
- Update `build.sbt` settings into a `milStd2045` project with recommend structure and updated cross-version support for Daffodil.
- Relocated `dtg_group`, `checkedInt`, and `invalidEnum` schema definitions for better maintainability in 3.6.0 through 4.1.0 since references were in places without the imports/includes that were required for older daffodil versions